### PR TITLE
CMake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ compiler:
   - gcc
 sudo: required
 env:
+    - CI_BUILD=cmake
     - CI_BUILD=autotools
 matrix:
   exclude:
@@ -26,17 +27,22 @@ addons:
     - libtool
     - pkg-config
     - libcunit1-dev
+    - cmake
+    - cmake-data
 before_install:
   - $CC --version
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then CMAKE_OPTS=" -DENABLE_ASAN=1" AUTOTOOLS_OPTS=" --enable-asan"; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then  if [ "$CXX" = "g++" ]; then export CXX="g++-8" CC="gcc-8" EXTRA_LDFLAGS="-fuse-ld=gold"; else export CXX="clang++" CC="clang"; fi; fi
   - $CC --version
+  - cmake --version
 before_script:
   # First build external lib
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install cunit; fi
   # configure nghttp3
   - if [ "$CI_BUILD" == "autotools" ]; then autoreconf -i; fi
   - if [ "$CI_BUILD" == "autotools" ]; then ./configure --enable-werror $AUTOTOOLS_OPTS; fi
+  - if [ "$CI_BUILD" == "cmake" ]; then cmake $CMAKE_OPTS .; fi
 script:
   # Now build nghttp3 examples and test
+  - make
   - make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,253 @@
+# nghttp3
+#
+# Copyright (c) 2019 nghttp3 contributors
+# Copyright (c) 2016 ngtcp2 contributors
+# Copyright (c) 2012 nghttp2 contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.1)
+# XXX using 0.1.90 instead of 0.1.0-DEV
+project(nghttp3 VERSION 0.1.90)
+
+# See versioning rule:
+#  http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+set(LT_CURRENT  0)
+set(LT_REVISION 0)
+set(LT_AGE      0)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(Version)
+
+math(EXPR LT_SOVERSION "${LT_CURRENT} - ${LT_AGE}")
+set(LT_VERSION "${LT_SOVERSION}.${LT_AGE}.${LT_REVISION}")
+set(PACKAGE_VERSION     "${PROJECT_VERSION}")
+HexVersion(PACKAGE_VERSION_NUM ${PROJECT_VERSION_MAJOR} ${PROJECT_VERSION_MINOR} ${PROJECT_VERSION_PATCH})
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the build type" FORCE)
+
+  # Include "None" as option to disable any additional (optimization) flags,
+  # relying on just CMAKE_C_FLAGS and CMAKE_CXX_FLAGS (which are empty by
+  # default). These strings are presented in cmake-gui.
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "None" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+include(GNUInstallDirs)
+
+include(CMakeOptions.txt)
+
+# Do not disable assertions based on CMAKE_BUILD_TYPE.
+foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
+  foreach(_lang C CXX)
+    string(TOUPPER "CMAKE_${_lang}_FLAGS_${_build_type}" _var)
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" "" ${_var} "${${_var}}")
+  endforeach()
+endforeach()
+
+find_package(CUnit 2.1)
+enable_testing()
+set(HAVE_CUNIT      ${CUNIT_FOUND})
+if(HAVE_CUNIT)
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+# Checks for header files.
+include(CheckIncludeFile)
+check_include_file("arpa/inet.h"   HAVE_ARPA_INET_H)
+check_include_file("stddef.h"      HAVE_STDDEF_H)
+check_include_file("stdint.h"      HAVE_STDINT_H)
+check_include_file("stdlib.h"      HAVE_STDLIB_H)
+check_include_file("string.h"      HAVE_STRING_H)
+check_include_file("unistd.h"      HAVE_UNISTD_H)
+
+include(CheckTypeSize)
+# Checks for typedefs, structures, and compiler characteristics.
+# AC_TYPE_SIZE_T
+check_type_size("ssize_t" SIZEOF_SSIZE_T)
+if(SIZEOF_SSIZE_T STREQUAL "")
+  # ssize_t is a signed type in POSIX storing at least -1.
+  # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
+  set(ssize_t int)
+endif()
+
+include(ExtractValidFlags)
+set(WARNCFLAGS)
+set(WARNCXXFLAGS)
+if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+  if(ENABLE_WERROR)
+    set(WARNCFLAGS    /WX)
+    set(WARNCXXFLAGS  /WX)
+  endif()
+else()
+  if(ENABLE_WERROR)
+    extract_valid_c_flags(WARNCFLAGS    -Werror)
+    extract_valid_c_flags(WARNCXXFLAGS  -Werror)
+  endif()
+
+  # For C compiler
+  extract_valid_c_flags(WARNCFLAGS
+    -Wall
+    -Wextra
+    -Wmissing-prototypes
+    -Wstrict-prototypes
+    -Wmissing-declarations
+    -Wpointer-arith
+    -Wdeclaration-after-statement
+    -Wformat-security
+    -Wwrite-strings
+    -Wshadow
+    -Winline
+    -Wnested-externs
+    -Wfloat-equal
+    -Wundef
+    -Wendif-labels
+    -Wempty-body
+    -Wcast-align
+    -Wclobbered
+    -Wvla
+    -Wpragmas
+    -Wunreachable-code
+    -Waddress
+    -Wattributes
+    -Wdiv-by-zero
+    -Wshorten-64-to-32
+
+    -Wconversion
+    -Wextended-offsetof
+    -Wformat-nonliteral
+    -Wlanguage-extension-token
+    -Wmissing-field-initializers
+    -Wmissing-noreturn
+    -Wmissing-variable-declarations
+    # Not used because we cannot change public structs
+    # -Wpadded
+    -Wsign-conversion
+    # Not used because this basically disallows default case
+    # -Wswitch-enum
+    -Wunreachable-code-break
+    -Wunused-macros
+    -Wunused-parameter
+    -Wredundant-decls
+    # Only work with Clang for the moment
+    -Wheader-guard
+    -Wsometimes-uninitialized
+
+    # Only work with gcc7 for the moment
+    -Wduplicated-branches
+    # This is required because we pass format string as "const char*.
+    -Wno-format-nonliteral
+  )
+
+  extract_valid_cxx_flags(WARNCXXFLAGS
+    # For C++ compiler
+    -Wall
+    -Wformat-security
+    -Wsometimes-uninitialized
+    # Disable noexcept-type warning of g++-7.  This is not harmful as
+    # long as all source files are compiled with the same compiler.
+    -Wno-noexcept-type
+  )
+
+  if(ENABLE_ASAN)
+    include(CMakePushCheckState)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES "-fsanitize=address")
+    check_c_compiler_flag(-fsanitize=address C__fsanitize_address_VALID)
+    check_cxx_compiler_flag(-fsanitize=address CXX__fsanitize_address_VALID)
+    cmake_pop_check_state()
+    if(NOT C__fsanitize_address_VALID OR NOT CXX__fsanitize_address_VALID)
+      message(WARNING "ENABLE_ASAN was requested, but not supported!")
+    else()
+      set(CMAKE_C_FLAGS "-fsanitize=address ${CMAKE_C_FLAGS}")
+      set(CMAKE_CXX_FLAGS "-fsanitize=address ${CMAKE_CXX_FLAGS}")
+    endif()
+  endif()
+endif()
+
+if(ENABLE_DEBUG)
+  set(DEBUGBUILD 1)
+endif()
+
+if(ENABLE_LIB_ONLY)
+  set(ENABLE_EXAMPLES 0)
+else()
+  set(ENABLE_EXAMPLES 1)
+endif()
+
+add_definitions(-DHAVE_CONFIG_H)
+configure_file(cmakeconfig.h.in config.h)
+# autotools-compatible names
+# Sphinx expects relative paths in the .rst files. Use the fact that the files
+# below are all one directory level deep.
+file(RELATIVE_PATH top_srcdir   "${CMAKE_CURRENT_BINARY_DIR}/dir" "${CMAKE_CURRENT_SOURCE_DIR}")
+file(RELATIVE_PATH top_builddir "${CMAKE_CURRENT_BINARY_DIR}/dir" "${CMAKE_CURRENT_BINARY_DIR}")
+set(abs_top_srcdir  "${CMAKE_CURRENT_SOURCE_DIR}")
+set(abs_top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
+# libnghttp3.pc (pkg-config file)
+set(prefix          "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix     "${CMAKE_INSTALL_PREFIX}")
+set(libdir          "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(includedir      "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(VERSION         "${PACKAGE_VERSION}")
+# For init scripts and systemd service file (in contrib/)
+set(bindir          "${CMAKE_INSTALL_FULL_BINDIR}")
+set(sbindir         "${CMAKE_INSTALL_FULL_SBINDIR}")
+foreach(name
+  lib/libnghttp3.pc
+  lib/includes/nghttp3/version.h
+)
+  configure_file("${name}.in" "${name}" @ONLY)
+endforeach()
+
+include_directories(
+  "${CMAKE_CURRENT_BINARY_DIR}" # for config.h
+)
+# For use in src/CMakeLists.txt
+set(PKGDATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")
+
+install(FILES README.rst DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+
+add_subdirectory(lib)
+add_subdirectory(tests)
+add_subdirectory(examples)
+
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type)
+message(STATUS "summary of build options:
+
+    Package version: ${VERSION}
+    Library version: ${LT_CURRENT}:${LT_REVISION}:${LT_AGE}
+    Install prefix:  ${CMAKE_INSTALL_PREFIX}
+    Target system:   ${CMAKE_SYSTEM_NAME}
+    Compiler:
+      Build type:     ${CMAKE_BUILD_TYPE}
+      C compiler:     ${CMAKE_C_COMPILER}
+      CFLAGS:         ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
+      C++ compiler:   ${CMAKE_CXX_COMPILER}
+      CXXFLAGS:       ${CMAKE_CXX_FLAGS_${_build_type}} ${CMAKE_CXX_FLAGS}
+      WARNCFLAGS:     ${WARNCFLAGS}
+      WARNCXXFLAGS:   ${WARNCXXFLAGS}
+    Test:
+      CUnit:          ${HAVE_CUNIT} (LIBS='${CUNIT_LIBRARIES}')
+    Library only:     ${ENABLE_LIB_ONLY}
+    Examples:         ${ENABLE_EXAMPLES}
+")

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -1,0 +1,8 @@
+# Features that can be enabled for cmake (see CMakeLists.txt)
+
+option(ENABLE_WERROR    "Make compiler warnings fatal" OFF)
+option(ENABLE_DEBUG     "Turn on debug output")
+option(ENABLE_ASAN      "Enable AddressSanitizer (ASAN)" OFF)
+option(ENABLE_LIB_ONLY  "Build libnghttp3 only" OFF)
+
+# vim: ft=cmake:

--- a/cmake/ExtractValidFlags.cmake
+++ b/cmake/ExtractValidFlags.cmake
@@ -1,0 +1,31 @@
+# Convenience function that checks the availability of certain
+# C or C++ compiler flags and returns valid ones as a string.
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
+function(extract_valid_c_flags varname)
+  set(valid_flags)
+  foreach(flag IN LISTS ARGN)
+    string(REGEX REPLACE "[^a-zA-Z0-9_]+" "_" flag_var ${flag})
+    set(flag_var "C_FLAG_${flag_var}")
+    check_c_compiler_flag("${flag}" "${flag_var}")
+    if(${flag_var})
+      set(valid_flags "${valid_flags} ${flag}")
+    endif()
+  endforeach()
+  set(${varname} "${valid_flags}" PARENT_SCOPE)
+endfunction()
+
+function(extract_valid_cxx_flags varname)
+  set(valid_flags)
+  foreach(flag IN LISTS ARGN)
+    string(REGEX REPLACE "[^a-zA-Z0-9_]+" "_" flag_var ${flag})
+    set(flag_var "CXX_FLAG_${flag_var}")
+    check_cxx_compiler_flag("${flag}" "${flag_var}")
+    if(${flag_var})
+      set(valid_flags "${valid_flags} ${flag}")
+    endif()
+  endforeach()
+  set(${varname} "${valid_flags}" PARENT_SCOPE)
+endfunction()

--- a/cmake/FindCUnit.cmake
+++ b/cmake/FindCUnit.cmake
@@ -1,0 +1,40 @@
+# - Try to find cunit
+# Once done this will define
+#  CUNIT_FOUND        - System has cunit
+#  CUNIT_INCLUDE_DIRS - The cunit include directories
+#  CUNIT_LIBRARIES    - The libraries needed to use cunit
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_CUNIT QUIET cunit)
+
+find_path(CUNIT_INCLUDE_DIR
+  NAMES CUnit/CUnit.h
+  HINTS ${PC_CUNIT_INCLUDE_DIRS}
+)
+find_library(CUNIT_LIBRARY
+  NAMES cunit
+  HINTS ${PC_CUNIT_LIBRARY_DIRS}
+)
+
+if(CUNIT_INCLUDE_DIR)
+  set(_version_regex "^#define[ \t]+CU_VERSION[ \t]+\"([^\"]+)\".*")
+  file(STRINGS "${CUNIT_INCLUDE_DIR}/CUnit/CUnit.h"
+    CUNIT_VERSION REGEX "${_version_regex}")
+  string(REGEX REPLACE "${_version_regex}" "\\1"
+    CUNIT_VERSION "${CUNIT_VERSION}")
+  unset(_version_regex)
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CUNIT_FOUND to TRUE
+# if all listed variables are TRUE and the requested version matches.
+find_package_handle_standard_args(CUnit REQUIRED_VARS
+                                  CUNIT_LIBRARY CUNIT_INCLUDE_DIR
+                                  VERSION_VAR CUNIT_VERSION)
+
+if(CUNIT_FOUND)
+  set(CUNIT_LIBRARIES     ${CUNIT_LIBRARY})
+  set(CUNIT_INCLUDE_DIRS  ${CUNIT_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(CUNIT_INCLUDE_DIR CUNIT_LIBRARY)

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,0 +1,11 @@
+# Converts a version such as 1.2.255 to 0x0102ff
+function(HexVersion version_hex_var major minor patch)
+  math(EXPR version_dec "${major} * 256 * 256 + ${minor} * 256 + ${patch}")
+  set(version_hex "0x")
+  foreach(i RANGE 5 0 -1)
+    math(EXPR num "(${version_dec} >> (4 * ${i})) & 15")
+    string(SUBSTRING "0123456789abcdef" ${num} 1 num_hex)
+    set(version_hex "${version_hex}${num_hex}")
+  endforeach()
+  set(${version_hex_var} "${version_hex}" PARENT_SCOPE)
+endfunction()

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -1,0 +1,24 @@
+
+/* Define to `int' if <sys/types.h> does not define. */
+#cmakedefine ssize_t @ssize_t@
+
+/* Define to 1 to enable debug output. */
+#cmakedefine DEBUGBUILD 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#cmakedefine HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#cmakedefine HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1

--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,6 @@ AC_MSG_NOTICE([summary of build options:
       CUnit:          ${have_cunit} (CFLAGS='${CUNIT_CFLAGS}' LIBS='${CUNIT_LIBS}')
     Debug:
       Debug:          ${debug} (CFLAGS='${DEBUGCFLAGS}')
-    Libray only:      ${lib_only}
+    Library only:     ${lib_only}
     Examples:         ${enable_examples}
 ])

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,50 @@
+# ngtcp3
+#
+# Copyright (c) 2019 nghttp3 contributors
+# Copyright (c) 2017 ngtcp2 contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if(ENABLE_EXAMPLES)
+  include_directories(
+    ${CMAKE_SOURCE_DIR}/lib/includes
+    ${CMAKE_BINARY_DIR}/lib/includes
+  )
+
+  link_libraries(
+    nghttp3
+  )
+
+  set(qpack_SOURCES
+    qpack.cc
+    qpack_encode.cc
+    qpack_decode.cc
+    util.cc
+  )
+
+  add_executable(qpack ${qpack_SOURCES})
+  set_target_properties(qpack PROPERTIES
+    COMPILE_FLAGS "${WARNCXXFLAGS}"
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+  )
+
+  # TODO prevent qpack example from being installed?
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,84 @@
+# nghttp3
+#
+# Copyright (c) 2019 nghttp3
+# Copyright (c) 2016 ngtcp2
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+add_subdirectory(includes)
+
+include_directories(
+  "${CMAKE_CURRENT_SOURCE_DIR}/includes"
+  "${CMAKE_CURRENT_BINARY_DIR}/includes"
+)
+
+add_definitions(-DBUILDING_NGHTTP3)
+
+set(nghttp3_SOURCES
+  nghttp3_rcbuf.c
+  nghttp3_mem.c
+  nghttp3_str.c
+  nghttp3_conv.c
+  nghttp3_buf.c
+  nghttp3_ringbuf.c
+  nghttp3_pq.c
+  nghttp3_map.c
+  nghttp3_ksl.c
+  nghttp3_qpack.c
+  nghttp3_qpack_huffman.c
+  nghttp3_qpack_huffman_data.c
+  nghttp3_err.c
+  nghttp3_debug.c
+  nghttp3_conn.c
+  nghttp3_stream.c
+  nghttp3_frame.c
+  nghttp3_tnode.c
+  nghttp3_vec.c
+  nghttp3_psl.c
+  nghttp3_gaptr.c
+  nghttp3_idtr.c
+  nghttp3_range.c
+  nghttp3_http.c
+)
+
+# Public shared library
+add_library(nghttp3 SHARED ${nghttp3_SOURCES})
+set_target_properties(nghttp3 PROPERTIES
+  COMPILE_FLAGS "${WARNCFLAGS}"
+  VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+  C_VISIBILITY_PRESET hidden
+)
+
+if(HAVE_CUNIT)
+  # Static library (for unittests because of symbol visibility)
+  add_library(nghttp3_static STATIC ${nghttp3_SOURCES})
+  set_target_properties(nghttp3_static PROPERTIES
+    COMPILE_FLAGS "${WARNCFLAGS}"
+    VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME nghttp3
+  )
+  target_compile_definitions(nghttp3_static PUBLIC "-DNGHTTP3_STATICLIB")
+endif()
+
+install(TARGETS nghttp3
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libnghttp3.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/lib/includes/CMakeLists.txt
+++ b/lib/includes/CMakeLists.txt
@@ -1,0 +1,4 @@
+install(FILES
+    nghttp3/nghttp3.h
+    "${CMAKE_CURRENT_BINARY_DIR}/nghttp3/version.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nghttp3")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+# nghttp3
+#
+# Copyright (c) 2019 nghttp3 contributors
+# Copyright (c) 2016 ngtcp2 contributors
+# Copyright (c) 2012 nghttp2 contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+if(HAVE_CUNIT)
+  include_directories(
+    "${CMAKE_SOURCE_DIR}/lib"
+    "${CMAKE_SOURCE_DIR}/lib/includes"
+    "${CMAKE_BINARY_DIR}/lib/includes"
+    ${CUNIT_INCLUDE_DIRS}
+  )
+
+  set(main_SOURCES
+    main.c
+    nghttp3_qpack_test.c
+    nghttp3_conn_test.c
+    nghttp3_tnode_test.c
+    nghttp3_test_helper.c
+  )
+
+  add_executable(main EXCLUDE_FROM_ALL
+    ${main_SOURCES}
+  )
+  target_include_directories(main PRIVATE ${CUNIT_INCLUDE_DIRS})
+  # FIXME enable and fix warnings
+  #set_target_properties(main PROPERTIES COMPILE_FLAGS "${WARNCFLAGS}")
+  target_link_libraries(main
+    nghttp3_static
+    ${CUNIT_LIBRARIES}
+  )
+  add_test(main main)
+  add_dependencies(check main)
+endif()


### PR DESCRIPTION
Similar to https://github.com/ngtcp2/ngtcp2/pull/45, this adds CMake support. Main motivation for this is being able to build ngtcp2+nghttp3 out-of-tree such that I can create a draft -19 test capture.