### PR TITLE
More stringent compilation warnings in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ else()
 
   extract_valid_cxx_flags(WARNCXXFLAGS
     # For C++ compiler
+    -Wextra
     -Wall
     -Wformat-security
     -Wsometimes-uninitialized

--- a/examples/qpack_encode.cc
+++ b/examples/qpack_encode.cc
@@ -180,7 +180,7 @@ int encode(const std::string_view &outfile, const std::string_view &infile) {
           const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(name.data())),
           const_cast<uint8_t *>(
               reinterpret_cast<const uint8_t *>(value.data())),
-          name.size(), value.size()});
+          name.size(), value.size(), NGHTTP3_NV_FLAG_NONE});
     }
 
     if (nva.empty()) {


### PR DESCRIPTION
Added `-Wextra` flag to CXX warning flags to catch more potential issues in the example files. 

Compiling with `-Wextra` revealed a missing value for the flag parameter while initializing the `nghttp3_nv` environment value. 

Added the missing parameter with the default value of `NGHTTP3_NV_FLAG_NONE` to fix the compilation warning.