### PR TITLE
Change nghttp3_ringbuf.c "title" to nghttp3

### DIFF
--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -1,5 +1,5 @@
 /*
- * ngtcp2
+ * nghttp3
  *
  * Copyright (c) 2019 nghttp3 contributors
  * Copyright (c) 2017 ngtcp2 contributors


### PR DESCRIPTION
This commit changes ngtcp2 to nghttp3 to be consistent with other
header and source files.