### PR TITLE
Restore Windows build for the nghttp3 library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,6 +66,10 @@ set_target_properties(nghttp3 PROPERTIES
   C_VISIBILITY_PRESET hidden
 )
 
+if(WIN32)
+	target_link_libraries(nghttp3 PUBLIC ws2_32)
+endif(WIN32)
+
 if(HAVE_CUNIT)
   # Static library (for unittests because of symbol visibility)
   add_library(nghttp3_static STATIC ${nghttp3_SOURCES})

--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -27,13 +27,20 @@
 
 #include <assert.h>
 #include <string.h>
+#ifdef WIN32
+  #include <intrin.h>
+#endif
 
 #include "nghttp3_macro.h"
 
 int nghttp3_ringbuf_init(nghttp3_ringbuf *rb, size_t nmemb, size_t size,
                          const nghttp3_mem *mem) {
   if (nmemb) {
-    assert(1 == __builtin_popcount((unsigned int)nmemb));
+    #ifdef WIN32
+      assert(1 == __popcnt((unsigned int)nmemb));
+    #else
+      assert(1 == __builtin_popcount((unsigned int)nmemb));
+    #endif
 
     rb->buf = nghttp3_mem_malloc(mem, nmemb * size);
     if (rb->buf == NULL) {
@@ -111,7 +118,11 @@ int nghttp3_ringbuf_reserve(nghttp3_ringbuf *rb, size_t nmemb) {
     return 0;
   }
 
-  assert(1 == __builtin_popcount((unsigned int)nmemb));
+  #ifdef WIN32
+    assert(1 == __popcnt((unsigned int)nmemb));
+  #else
+    assert(1 == __builtin_popcount((unsigned int)nmemb));
+  #endif
 
   buf = nghttp3_mem_malloc(rb->mem, nmemb * rb->size);
   if (buf == NULL) {


### PR DESCRIPTION
Hi,

a simple modification to enable the Windows build that does not necessarily embed __builtin_popcount and need to be linked against WinSock2 for utility functions like ntohs.

I based this on ngtcp2 development (see ngtcp2/lib/ngtcp2_ringbuf.c commit 119f88ce06b68dd7beeb173039151c4a187cb696)