### PR TITLE
Fix DEBUGBUILD always being defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,6 @@ AC_ARG_ENABLE([debug],
 if test "x${debug}" = "x${enableval}"; then
   DEBUGCFLAGS="-O0 -g3"
   AC_SUBST([DEBUGCFLAGS])
-  AC_DEFINE([DEBUGBUILD], [1], [Define to 1 to enable debug output.])
 fi
 
 AC_ARG_ENABLE(asan,


### PR DESCRIPTION
I noticed that even when `--enable-debug` isn't passed to `configure` the `DEBUGBUILD` macro was always defined and some `DEBUGF` output was being output even for optimized builds.