### PR TITLE
Fix overflow of min_dtable_update

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -1184,8 +1184,8 @@ typedef struct {
 typedef struct {
   uint64_t max_header_list_size;
   uint64_t max_pushes;
-  uint64_t qpack_max_table_capacity;
-  uint64_t qpack_blocked_streams;
+  size_t qpack_max_table_capacity;
+  size_t qpack_blocked_streams;
 } nghttp3_conn_settings;
 
 NGHTTP3_EXTERN void

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2167,8 +2167,8 @@ int nghttp3_conn_on_settings_entry_received(nghttp3_conn *conn,
   const nghttp3_settings_entry *ent = &fr->iv[0];
   nghttp3_conn_settings *dest = &conn->remote.settings;
   int rv;
-  uint64_t max_table_capacity = NGHTTP3_QPACK_ENCODER_MAX_TABLE_CAPACITY;
-  uint64_t max_blocked_streams = NGHTTP3_QPACK_ENCODER_MAX_BLOCK_STREAMS;
+  size_t max_table_capacity = SIZE_MAX;
+  size_t max_blocked_streams = SIZE_MAX;
 
   /* TODO Check for duplicates */
   switch (ent->id) {
@@ -2176,7 +2176,7 @@ int nghttp3_conn_on_settings_entry_received(nghttp3_conn *conn,
     dest->max_header_list_size = ent->value;
     break;
   case NGHTTP3_SETTINGS_ID_QPACK_MAX_TABLE_CAPACITY:
-    dest->qpack_max_table_capacity = ent->value;
+    dest->qpack_max_table_capacity = (size_t)ent->value;
     max_table_capacity =
         nghttp3_min(max_table_capacity, dest->qpack_max_table_capacity);
     rv = nghttp3_qpack_encoder_set_hard_max_dtable_size(&conn->qenc,
@@ -2191,7 +2191,7 @@ int nghttp3_conn_on_settings_entry_received(nghttp3_conn *conn,
     }
     break;
   case NGHTTP3_SETTINGS_ID_QPACK_BLOCKED_STREAMS:
-    dest->qpack_blocked_streams = ent->value;
+    dest->qpack_blocked_streams = (size_t)ent->value;
     max_blocked_streams =
         nghttp3_min(max_blocked_streams, dest->qpack_blocked_streams);
     rv =

--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -917,7 +917,7 @@ int nghttp3_qpack_encoder_init(nghttp3_qpack_encoder *encoder,
   encoder->krcnt = 0;
   encoder->state = NGHTTP3_QPACK_DS_STATE_OPCODE;
   encoder->opcode = 0;
-  encoder->min_dtable_update = NGHTTP3_QPACK_INT_MAX;
+  encoder->min_dtable_update = SIZE_MAX;
   encoder->last_max_dtable_update = 0;
   encoder->flags = NGHTTP3_QPACK_ENCODER_FLAG_NONE;
 
@@ -1275,7 +1275,7 @@ int nghttp3_qpack_encoder_process_dtable_update(nghttp3_qpack_encoder *encoder,
   }
 
   encoder->flags &= (uint8_t)~NGHTTP3_QPACK_ENCODER_FLAG_PENDING_SET_DTABLE_CAP;
-  encoder->min_dtable_update = NGHTTP3_QPACK_INT_MAX;
+  encoder->min_dtable_update = SIZE_MAX;
   encoder->ctx.max_dtable_size = encoder->last_max_dtable_update;
 
   return 0;

--- a/tests/nghttp3_qpack_test.c
+++ b/tests/nghttp3_qpack_test.c
@@ -451,7 +451,7 @@ void test_nghttp3_qpack_encoder_set_dtable_cap(void) {
   CU_ASSERT(0 == enc.ctx.dtable_size);
   CU_ASSERT(0 == enc.ctx.max_dtable_size);
   CU_ASSERT(0 == enc.last_max_dtable_update);
-  CU_ASSERT(NGHTTP3_QPACK_INT_MAX == enc.min_dtable_update);
+  CU_ASSERT(SIZE_MAX == enc.min_dtable_update);
   CU_ASSERT(0 == nghttp3_qpack_encoder_get_num_blocked(&enc));
 
   nread = nghttp3_qpack_decoder_read_encoder(&dec, ebuf.pos,
@@ -516,7 +516,7 @@ void test_nghttp3_qpack_encoder_set_dtable_cap(void) {
   CU_ASSERT(2 == enc.ctx.next_absidx);
   CU_ASSERT(strlen("foo1") + strlen("bar1") + NGHTTP3_QPACK_ENTRY_OVERHEAD ==
             enc.ctx.dtable_size);
-  CU_ASSERT(NGHTTP3_QPACK_INT_MAX == enc.min_dtable_update);
+  CU_ASSERT(SIZE_MAX == enc.min_dtable_update);
   CU_ASSERT(1024 == enc.last_max_dtable_update);
   CU_ASSERT(1024 == enc.ctx.max_dtable_size);
 


### PR DESCRIPTION
size_t is 32-bit on 32-bit machines and min_dtable_update was assigned NGHTTP3_QPACK_INT_MAX, which is 64 bits. This failed the tests on 32-bit machines.

There are a few other places in nghttp3_qpack where uint64_t values are assigned to size_t variables and need to be fixed.