### PR TITLE
Fix ntonl linking errors on Windows

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,10 +66,6 @@ set_target_properties(nghttp3 PROPERTIES
   C_VISIBILITY_PRESET hidden
 )
 
-if(WIN32)
-	target_link_libraries(nghttp3 PUBLIC ws2_32)
-endif(WIN32)
-
 if(HAVE_CUNIT)
   # Static library (for unittests because of symbol visibility)
   add_library(nghttp3_static STATIC ${nghttp3_SOURCES})

--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -58,6 +58,55 @@
 #  define nghttp3_htonl64(N) nghttp3_bswap64(N)
 #endif /* !HAVE_BE64TOH */
 
+#if defined(WIN32)
+/* Windows requires ws2_32 library for ntonl family of functions.  We
+   define inline functions for those functions so that we don't have
+   dependency on that lib. */
+
+#  ifdef _MSC_VER
+#    define STIN static __inline
+#  else
+#    define STIN static inline
+#  endif
+
+STIN uint32_t htonl(uint32_t hostlong) {
+  uint32_t res;
+  unsigned char *p = (unsigned char *)&res;
+  *p++ = hostlong >> 24;
+  *p++ = (hostlong >> 16) & 0xffu;
+  *p++ = (hostlong >> 8) & 0xffu;
+  *p = hostlong & 0xffu;
+  return res;
+}
+
+STIN uint16_t htons(uint16_t hostshort) {
+  uint16_t res;
+  unsigned char *p = (unsigned char *)&res;
+  *p++ = hostshort >> 8;
+  *p = hostshort & 0xffu;
+  return res;
+}
+
+STIN uint32_t ntohl(uint32_t netlong) {
+  uint32_t res;
+  unsigned char *p = (unsigned char *)&netlong;
+  res = *p++ << 24;
+  res += *p++ << 16;
+  res += *p++ << 8;
+  res += *p;
+  return res;
+}
+
+STIN uint16_t ntohs(uint16_t netshort) {
+  uint16_t res;
+  unsigned char *p = (unsigned char *)&netshort;
+  res = *p++ << 8;
+  res += *p;
+  return res;
+}
+
+#endif /* WIN32 */
+
 /*
  * nghttp3_get_varint reads variable-length integer from |p|, and
  * returns it in host byte order.  The number of bytes read is stored


### PR DESCRIPTION
On Windows, the `ntonl` family of functions is declared in `Winsock.h` and defined in `ws2_32.lib`. The nghttp3 library doesn't include `Winsock.h` anywhere, so the usage of these `ntonl` functions was causing an implicit reference to these functions using the wrong calling convention (`__cdecl` instead of `__stdcall`). Later, when linking `nghttp3_static.lib` into an application (e.g. `curl`), these undefined references couldn't be resolved due to the signature mismatch:

```
1>nghttp3.lib(nghttp3_conv.obj) : error LNK2001: unresolved external symbol _htonl
1>  Hint on symbols that are defined and could potentially match:
1>    _htonl@4
```

Note: `_htonl` is the cdecl version of `htonl`, whereas `_htonl@4` is the stdcall version.

This change adds definitions for the `ntonl` family of functions directly in the `nghttp3` library like ngtcp2 did (see https://github.com/ngtcp2/ngtcp2/commit/3f30a4b281133c8518758151f59d94ccd9a7aea7#diff-f79bf272f5349f5a6f3e99bee1e67d57) so there's no Winsock dependency anywhere.