### PR TITLE
Don't copy from unallocated buffer in nghttp3_qpack_decoder_write_decoder

### DIFF
--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -3663,8 +3663,11 @@ void nghttp3_qpack_decoder_write_decoder(nghttp3_qpack_decoder *decoder,
 
   assert(nghttp3_buf_left(dbuf) >= nghttp3_buf_len(&decoder->dbuf) + len);
 
-  dbuf->last = nghttp3_cpymem(dbuf->last, decoder->dbuf.pos,
-                              nghttp3_buf_len(&decoder->dbuf));
+  if (decoder->dbuf.pos != NULL) {
+    dbuf->last = nghttp3_cpymem(dbuf->last, decoder->dbuf.pos,
+                                nghttp3_buf_len(&decoder->dbuf));
+  }
+
   if (n) {
     p = dbuf->last;
     *p = 0;


### PR DESCRIPTION
When decoding large headers, this call can result in a call to `memcpy()` with a `NULL` src, which is undefined behavior.