### PR TITLE
Fix definition of ssize_t in CMake for 64-bit builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ include(CheckTypeSize)
 check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
-  # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  set(ssize_t int)
+  # Set it to a pointer-size int.
+  set(ssize_t ptrdiff_t)
 endif()
 
 # Checks for symbols.


### PR DESCRIPTION
When using `CMake` to build nghttp3, the definition of `ssize_t` is incorrect for 64-bit builds. It's defined as an `int`, which at least on Windows is a 32-bit type.

What this means is that any nghttp3 function that returns an error code ends up returning a bit pattern that, on 64-bit builds, is interpreted by the caller as a _large positive number_ instead of a _small negative number_. That's because the caller (e.g. libcurl) will probably have a different definition of `ssize_t`, one that is correctly sized as a signed 64-bit integer, not a signed 32-bit integer.

See https://github.com/ngtcp2/ngtcp2/pull/193 for more info.