### PR TITLE
Implement popcnt for windows arm64

### DIFF
--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -33,6 +33,14 @@
 
 #include "nghttp3_macro.h"
 
+#if defined(_MSC_VER) && defined(_M_ARM64)
+unsigned int __popcnt(unsigned int x) {
+  int c = 0;
+  for (; x; c++) x &= x - 1;
+  return c;
+}
+#endif
+
 int nghttp3_ringbuf_init(nghttp3_ringbuf *rb, size_t nmemb, size_t size,
                          const nghttp3_mem *mem) {
   if (nmemb) {


### PR DESCRIPTION
The popcnt intrinsic is not available on windows arm64. This provides a reasonably performant implementation.

See also: https://github.com/ngtcp2/ngtcp2/pull/263