### PR TITLE
cmake: add ENABLE_STATIC_LIB option to build a static library

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -1,8 +1,9 @@
 # Features that can be enabled for cmake (see CMakeLists.txt)
 
-option(ENABLE_WERROR    "Make compiler warnings fatal" OFF)
-option(ENABLE_DEBUG     "Turn on debug output")
-option(ENABLE_ASAN      "Enable AddressSanitizer (ASAN)" OFF)
-option(ENABLE_LIB_ONLY  "Build libnghttp3 only" OFF)
+option(ENABLE_WERROR     "Make compiler warnings fatal" OFF)
+option(ENABLE_DEBUG      "Turn on debug output")
+option(ENABLE_ASAN       "Enable AddressSanitizer (ASAN)" OFF)
+option(ENABLE_LIB_ONLY   "Build libnghttp3 only" OFF)
+option(ENABLE_STATIC_LIB "Build libnghttp3 in static mode also")
 
 # vim: ft=cmake:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,15 +66,19 @@ set_target_properties(nghttp3 PROPERTIES
   C_VISIBILITY_PRESET hidden
 )
 
-if(HAVE_CUNIT)
+if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   # Static library (for unittests because of symbol visibility)
   add_library(nghttp3_static STATIC ${nghttp3_SOURCES})
   set_target_properties(nghttp3_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-    ARCHIVE_OUTPUT_NAME nghttp3
+    ARCHIVE_OUTPUT_NAME nghttp3${STATIC_LIB_SUFFIX}
   )
   target_compile_definitions(nghttp3_static PUBLIC "-DNGHTTP3_STATICLIB")
+  if(ENABLE_STATIC_LIB)
+    install(TARGETS nghttp3_static
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+  endif()
 endif()
 
 install(TARGETS nghttp3


### PR DESCRIPTION
* static lib suffix can be controlled via STATIC_LIB_SUFFIX variable
* this solution is the same as already implemented in nghttp2