### PR TITLE
Fixed ambiguous type when returning a tuple

### DIFF
--- a/examples/qpack_decode.cc
+++ b/examples/qpack_decode.cc
@@ -96,16 +96,16 @@ std::tuple<Headers, int> Decoder::read_request(nghttp3_buf *buf,
 
   auto [headers, rv] = read_request(*req);
   if (rv == -1) {
-    return {{}, -1};
+    return {(Headers){}, -1};
   }
   if (rv == 1) {
     if (blocked_reqs_.size() >= max_blocked_) {
       std::cerr << "Too many blocked streams: max_blocked=" << max_blocked_
                 << std::endl;
-      return {{}, -1};
+      return {(Headers){}, -1};
     }
     blocked_reqs_.emplace(std::move(req));
-    return {{}, 1};
+    return {(Headers){}, 1};
   }
   return {headers, 0};
 }
@@ -121,7 +121,7 @@ std::tuple<Headers, int> Decoder::read_request(Request &req) {
     if (nread < 0) {
       std::cerr << "nghttp3_qpack_decoder_read_request: "
                 << nghttp3_strerror(nread) << std::endl;
-      return {{}, -1};
+      return {(Headers){}, -1};
     }
 
     req.buf.pos += nread;
@@ -130,7 +130,7 @@ std::tuple<Headers, int> Decoder::read_request(Request &req) {
       break;
     }
     if (flags & NGHTTP3_QPACK_DECODE_FLAG_BLOCKED) {
-      return {{}, 1};
+      return {(Headers){}, 1};
     }
     if (flags & NGHTTP3_QPACK_DECODE_FLAG_EMIT) {
       auto name = nghttp3_rcbuf_get_buf(nv.name);


### PR DESCRIPTION
I got this error when trying to compile on Fedora 34:

```
qpack_decode.cc: In member function ‘std::tuple<std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, int> nghttp3::Decoder::read_request(nghttp3_buf*, int64_t)’:
qpack_decode.cc:99:19: error: conversion from ‘<brace-enclosed initializer list>’ to ‘std::tuple<std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, int>’ is ambiguous
   99 |     return {{}, -1};
      |                   ^

```