### PR TITLE
adding reset stream function and some tests

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2408,6 +2408,11 @@ NGHTTP3_EXTERN int nghttp3_conn_submit_trailers(nghttp3_conn *conn,
                                                 const nghttp3_nv *nva,
                                                 size_t nvlen);
 
+
+NGHTTP3_EXTERN int nghttp3_conn_submit_reset_stream(nghttp3_conn *conn,
+                                                    int64_t stream_id,
+                                                    uint64_t error_code);
+
 /**
  * @function
  *

--- a/tests/main.c
+++ b/tests/main.c
@@ -79,6 +79,8 @@ int main() {
                    test_nghttp3_conn_write_control) ||
       !CU_add_test(pSuite, "conn_submit_request",
                    test_nghttp3_conn_submit_request) ||
+      !CU_add_test(pSuite, "conn_submit_request_and_reset",
+                   test_nghttp3_conn_submit_request_and_reset) ||
       !CU_add_test(pSuite, "conn_submit_push_promise",
                    test_nghttp3_conn_submit_push_promise) ||
       !CU_add_test(pSuite, "conn_http_request",
@@ -119,6 +121,8 @@ int main() {
                    test_nghttp3_conn_shutdown_client) ||
       !CU_add_test(pSuite, "conn_priority_update",
                    test_nghttp3_conn_priority_update) ||
+      !CU_add_test(pSuite, "conn_submit_reset_instead_of_response",
+                   test_nghttp3_conn_submit_reset_instead_of_response) ||
       !CU_add_test(pSuite, "conn_set_stream_priority",
                    test_nghttp3_conn_set_stream_priority) ||
       !CU_add_test(pSuite, "conn_set_push_priority",

--- a/tests/nghttp3_conn_test.h
+++ b/tests/nghttp3_conn_test.h
@@ -32,6 +32,7 @@
 void test_nghttp3_conn_read_control(void);
 void test_nghttp3_conn_write_control(void);
 void test_nghttp3_conn_submit_request(void);
+void test_nghttp3_conn_submit_request_and_reset(void);
 void test_nghttp3_conn_submit_push_promise(void);
 void test_nghttp3_conn_http_request(void);
 void test_nghttp3_conn_http_resp_header(void);
@@ -40,6 +41,7 @@ void test_nghttp3_conn_http_content_length(void);
 void test_nghttp3_conn_http_content_length_mismatch(void);
 void test_nghttp3_conn_http_non_final_response(void);
 void test_nghttp3_conn_http_trailers(void);
+void test_nghttp3_conn_submit_reset_instead_of_response(void);
 void test_nghttp3_conn_http_ignore_content_length(void);
 void test_nghttp3_conn_http_record_request_method(void);
 void test_nghttp3_conn_qpack_blocked_stream(void);


### PR DESCRIPTION
Attempt to add a nghttp2_submit_rst_stream alternative. It seems to work (for simple single request/response exchanges...), but I am far from certain that it is correct; and the test are for sure not checking for correct stuff (reset callback etc.)...

It behaves similarly to nghttp2's rst_stream (does not invoke stream_close callback), also does not ack pending data. No idea what is a correct behavior but at least not invoking stream_close seems correct to me.

Please tatsuhiro-t, could you eventually add a clean implementation of this?

