### PR TITLE
Add fin parameter to nghttp3_end_headers callback

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -1708,13 +1708,15 @@ typedef int (*nghttp3_recv_header)(nghttp3_conn *conn, int64_t stream_id,
  * :type:`nghttp3_end_headers` is a callback function which is invoked
  * when an incoming header block has ended.
  *
+ * If the stream ends with this header block, |fin| is set to nonzero.
+ *
  * The implementation of this callback must return 0 if it succeeds.
  * Returning :macro:`NGHTTP3_ERR_CALLBACK_FAILURE` will return to the
  * caller immediately.  Any values other than 0 is treated as
  * :macro:`NGHTTP3_ERR_CALLBACK_FAILURE`.
  */
 typedef int (*nghttp3_end_headers)(nghttp3_conn *conn, int64_t stream_id,
-                                   void *conn_user_data,
+                                   int fin, void *conn_user_data,
                                    void *stream_user_data);
 
 /**

--- a/tests/nghttp3_conn_test.c
+++ b/tests/nghttp3_conn_test.c
@@ -103,10 +103,11 @@ static int recv_header(nghttp3_conn *conn, int64_t stream_id, int32_t token,
   return 0;
 }
 
-static int end_headers(nghttp3_conn *conn, int64_t stream_id, void *user_data,
-                       void *stream_user_data) {
+static int end_headers(nghttp3_conn *conn, int64_t stream_id, int fin,
+                       void *user_data, void *stream_user_data) {
   (void)conn;
   (void)stream_id;
+  (void)fin;
   (void)stream_user_data;
   (void)user_data;
   return 0;


### PR DESCRIPTION
Add fin parameter to nghttp3_end_headers callback to tell an
application that the stream has ended with this header block.
Previously, the application cannot know the stream has ended or not
and has to wait for nghttp3_end_stream callback to be invoked or
proceed as if the message might have a body.  This is not really
useful because if one chooses latter, you might need
transfer-encoding: chunked when forwarding the request in HTTP/1.1 hop
even if the method is GET.