### PR TITLE
nghttp3_rcbuf now stores nghttp3_mem in its field

### DIFF
--- a/lib/nghttp3_mem.c
+++ b/lib/nghttp3_mem.c
@@ -66,11 +66,6 @@ void nghttp3_mem_free(const nghttp3_mem *mem, void *ptr) {
   mem->free(ptr, mem->user_data);
 }
 
-void nghttp3_mem_free2(const nghttp3_free free_func, void *ptr,
-                       void *user_data) {
-  free_func(ptr, user_data);
-}
-
 void *nghttp3_mem_calloc(const nghttp3_mem *mem, size_t nmemb, size_t size) {
   return mem->calloc(nmemb, size, mem->user_data);
 }

--- a/lib/nghttp3_mem.h
+++ b/lib/nghttp3_mem.h
@@ -38,8 +38,6 @@
 #ifndef MEMDEBUG
 void *nghttp3_mem_malloc(const nghttp3_mem *mem, size_t size);
 void nghttp3_mem_free(const nghttp3_mem *mem, void *ptr);
-void nghttp3_mem_free2(const nghttp3_free free_func, void *ptr,
-                       void *user_data);
 void *nghttp3_mem_calloc(const nghttp3_mem *mem, size_t nmemb, size_t size);
 void *nghttp3_mem_realloc(const nghttp3_mem *mem, void *ptr, size_t size);
 #else /* MEMDEBUG */

--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -168,8 +168,8 @@ static nghttp3_qpack_static_entry token_stable[] = {
 /* Make scalar initialization form of nghttp3_qpack_static_entry */
 #define MAKE_STATIC_HD(N, V, T)                                                \
   {                                                                            \
-    {NULL, NULL, (uint8_t *)(N), sizeof((N)) - 1, -1},                         \
-        {NULL, NULL, (uint8_t *)(V), sizeof((V)) - 1, -1}, T                   \
+    {NULL, (uint8_t *)(N), sizeof((N)) - 1, -1},                               \
+        {NULL, (uint8_t *)(V), sizeof((V)) - 1, -1}, T                         \
   }
 
 static nghttp3_qpack_static_header stable[] = {

--- a/lib/nghttp3_rcbuf.c
+++ b/lib/nghttp3_rcbuf.c
@@ -41,8 +41,7 @@ int nghttp3_rcbuf_new(nghttp3_rcbuf **rcbuf_ptr, size_t size,
 
   *rcbuf_ptr = (void *)p;
 
-  (*rcbuf_ptr)->mem_user_data = mem->user_data;
-  (*rcbuf_ptr)->free = mem->free;
+  (*rcbuf_ptr)->mem = mem;
   (*rcbuf_ptr)->base = p + sizeof(nghttp3_rcbuf);
   (*rcbuf_ptr)->len = size;
   (*rcbuf_ptr)->ref = 1;
@@ -76,7 +75,7 @@ int nghttp3_rcbuf_new2(nghttp3_rcbuf **rcbuf_ptr, const uint8_t *src,
  * Frees |rcbuf| itself, regardless of its reference cout.
  */
 void nghttp3_rcbuf_del(nghttp3_rcbuf *rcbuf) {
-  nghttp3_mem_free2(rcbuf->free, rcbuf, rcbuf->mem_user_data);
+  nghttp3_mem_free(rcbuf->mem, rcbuf);
 }
 
 void nghttp3_rcbuf_incref(nghttp3_rcbuf *rcbuf) {

--- a/lib/nghttp3_rcbuf.h
+++ b/lib/nghttp3_rcbuf.h
@@ -33,10 +33,9 @@
 #include <nghttp3/nghttp3.h>
 
 struct nghttp3_rcbuf {
-  /* custom memory allocator belongs to the mem parameter when
-     creating this object. */
-  void *mem_user_data;
-  nghttp3_free free;
+  /* mem is the memory allocator that allocates memory for this
+     object. */
+  const nghttp3_mem *mem;
   /* The pointer to the underlying buffer */
   uint8_t *base;
   /* Size of buffer pointed by |base|. */


### PR DESCRIPTION
nghttp3_rcbuf now stores nghttp3_mem in its field.  The nghttp3_mem
object must be kept as long as nghttp3_rcbuf object exists.