### PR TITLE
Ignore priority header field in trailer fields

### DIFF
--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -943,11 +943,13 @@ static int http_request_on_header(nghttp3_http_state *http,
     }
     break;
   case NGHTTP3_QPACK_TOKEN_PRIORITY:
-    pri.urgency = nghttp3_pri_uint8_urgency(http->pri);
-    pri.inc = nghttp3_pri_uint8_inc(http->pri);
-    if (nghttp3_http_parse_priority(&pri, nv->value->base, nv->value->len) ==
-        0) {
-      http->pri = nghttp3_pri_to_uint8(&pri);
+    if (!trailers) {
+      pri.urgency = nghttp3_pri_uint8_urgency(http->pri);
+      pri.inc = nghttp3_pri_uint8_inc(http->pri);
+      if (nghttp3_http_parse_priority(&pri, nv->value->base, nv->value->len) ==
+          0) {
+        http->pri = nghttp3_pri_to_uint8(&pri);
+      }
     }
     break;
   default:


### PR DESCRIPTION
RFC9110 Section 16.3.2 states that each header field specification
needs to document that whether or not the header field is allowed in
trailers, and by default it will not be allowed.  RFC9218 does not say
anything about trailers, which means that priority header field is not
allowed in trailers.  Therefore, we ignore priority header field.