### PR TITLE
Do not allow leading or trailing SPC or HTAB in a field value

### DIFF
--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -1645,6 +1645,19 @@ static const int VALID_HD_VALUE_CHARS[] = {
 
 int nghttp3_check_header_value(const uint8_t *value, size_t len) {
   const uint8_t *last;
+
+  switch (len) {
+  case 0:
+    return 1;
+  case 1:
+    return !(*value == ' ' || *value == '\t');
+  default:
+    if (*value == ' ' || *value == '\t' || *(value + len - 1) == ' ' ||
+        *(value + len - 1) == '\t') {
+      return 0;
+    }
+  }
+
   for (last = value + len; value != last; ++value) {
     if (!VALID_HD_VALUE_CHARS[*value]) {
       return 0;

--- a/tests/main.c
+++ b/tests/main.c
@@ -124,6 +124,8 @@ int main(void) {
       !CU_add_test(pSuite, "sf_parse_item", test_nghttp3_sf_parse_item) ||
       !CU_add_test(pSuite, "sf_parse_inner_list",
                    test_nghttp3_sf_parse_inner_list) ||
+      !CU_add_test(pSuite, "check_header_value",
+                   test_nghttp3_check_header_value) ||
       !CU_add_test(pSuite, "pri_to_uint8", test_nghttp3_pri_to_uint8)) {
     CU_cleanup_registry();
     return (int)CU_get_error();

--- a/tests/nghttp3_http_test.c
+++ b/tests/nghttp3_http_test.c
@@ -653,3 +653,24 @@ void test_nghttp3_sf_parse_inner_list(void) {
     CU_ASSERT(-1 == nghttp3_sf_parse_inner_list(NULL, s, s + sizeof(s) - 1));
   }
 }
+
+#define check_header_value(S)                                                  \
+  nghttp3_check_header_value((const uint8_t *)S, sizeof(S) - 1)
+
+void test_nghttp3_check_header_value(void) {
+  uint8_t goodval[] = {'a', 'b', 0x80u, 'c', 0xffu, 'd'};
+  uint8_t badval1[] = {'a', 0x1fu, 'b'};
+  uint8_t badval2[] = {'a', 0x7fu, 'b'};
+
+  CU_ASSERT(check_header_value("!|}~"));
+  CU_ASSERT(!check_header_value(" !|}~"));
+  CU_ASSERT(!check_header_value("!|}~ "));
+  CU_ASSERT(!check_header_value("\t!|}~"));
+  CU_ASSERT(!check_header_value("!|}~\t"));
+  CU_ASSERT(check_header_value(goodval));
+  CU_ASSERT(!check_header_value(badval1));
+  CU_ASSERT(!check_header_value(badval2));
+  CU_ASSERT(check_header_value(""));
+  CU_ASSERT(!check_header_value(" "));
+  CU_ASSERT(!check_header_value("\t"));
+}

--- a/tests/nghttp3_http_test.h
+++ b/tests/nghttp3_http_test.h
@@ -32,5 +32,6 @@
 void test_nghttp3_http_parse_priority(void);
 void test_nghttp3_sf_parse_item(void);
 void test_nghttp3_sf_parse_inner_list(void);
+void test_nghttp3_check_header_value(void);
 
 #endif /* NGTCP2_CONN_TEST_H */


### PR DESCRIPTION
Do not allow leading or trailing SPC or HTAB in a field value, as per
https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.1

It is HTTP/2 specification, but I think it can be applicable to HTTP/3
as well.