### PR TITLE
Run tests for x86_64-w64-mingw32 host only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,9 @@ jobs:
       run: |
         make -j$(nproc)
         make -j$(nproc) check TESTS=""
+    - name: Run tests
+      if: matrix.host == 'x86_64-w64-mingw32'
+      run: |
         cd tests
         wine main.exe
 


### PR DESCRIPTION
GitHub Actions suddenly refused to install wine32 because of broken
dependencies.  In order to workaround this issue, do not run tests on
i686-w64-mingw32 host.