### PR TITLE
nghttp3_conn_get_frame_payload_left: Avoid NGHTTP3_ERR_STREAM_NOT_FOUND

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2368,11 +2368,10 @@ NGHTTP3_EXTERN int nghttp3_conn_set_stream_user_data(nghttp3_conn *conn,
  *
  * `nghttp3_conn_get_frame_payload_left` returns the number of bytes
  * left to read current frame payload for a stream denoted by
- * |stream_id|.  If no such stream is found, it returns
- * :macro:`NGHTTP3_ERR_STREAM_NOT_FOUND`.
+ * |stream_id|.  If no such stream is found, it returns 0.
  */
-NGHTTP3_EXTERN int64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
-                                                           int64_t stream_id);
+NGHTTP3_EXTERN uint64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
+                                                            int64_t stream_id);
 
 /**
  * @macrosection

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2461,15 +2461,15 @@ int nghttp3_conn_set_stream_user_data(nghttp3_conn *conn, int64_t stream_id,
   return 0;
 }
 
-int64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
-                                            int64_t stream_id) {
+uint64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
+                                             int64_t stream_id) {
   nghttp3_stream *stream = nghttp3_conn_find_stream(conn, stream_id);
 
   if (stream == NULL) {
-    return NGHTTP3_ERR_STREAM_NOT_FOUND;
+    return 0;
   }
 
-  return stream->rstate.left;
+  return (uint64_t)stream->rstate.left;
 }
 
 int nghttp3_conn_get_stream_priority(nghttp3_conn *conn, nghttp3_pri *dest,


### PR DESCRIPTION
Do not return NGHTTP3_ERR_STREAM_NOT_FOUND from
nghttp3_conn_get_frame_payload_left, and just return 0 if a stream is
not found.