### PR TITLE
nghttp3_conn_close_stream needs NGHTTP3_ERR_STREAM_NOT_FOUND

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2169,6 +2169,16 @@ NGHTTP3_EXTERN int nghttp3_conn_resume_stream(nghttp3_conn *conn,
  *
  * `nghttp3_conn_close_stream` closes stream identified by
  * |stream_id|.  |app_error_code| is the reason of the closure.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGHTTP3_ERR_STREAM_NOT_FOUND`
+ *     Stream not found.
+ * :macro:`NGHTTP3_ERR_H3_CLOSED_CRITICAL_STREAM`
+ *     A critical stream is closed.
+ * :macro:`NGHTTP3_ERR_CALLBACK_FAILURE`
+ *     User callback failed
  */
 NGHTTP3_EXTERN int nghttp3_conn_close_stream(nghttp3_conn *conn,
                                              int64_t stream_id,

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2377,7 +2377,7 @@ int nghttp3_conn_close_stream(nghttp3_conn *conn, int64_t stream_id,
   nghttp3_stream *stream = nghttp3_conn_find_stream(conn, stream_id);
 
   if (stream == NULL) {
-    return 0;
+    return NGHTTP3_ERR_STREAM_NOT_FOUND;
   }
 
   if (nghttp3_stream_uni(stream_id) &&


### PR DESCRIPTION
nghttp3_conn_close_stream needs NGHTTP3_ERR_STREAM_NOT_FOUND so that
an application can reliably extend stream limit if a stream is not
handled by nghttp3.