### PR TITLE
nghttp3_ringbuf: fix __popcnt with WIN ARM (32bits)

### DIFF
--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -33,7 +33,7 @@
 
 #include "nghttp3_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
 unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {


### PR DESCRIPTION
Fix __popcnt with Windows ARM (32 bits) 

found via https://github.com/microsoft/vcpkg/pull/26497 