### PR TITLE
Rename nghttp3_get_varint_len and nghttp3_put_varint_len

### DIFF
--- a/lib/nghttp3_conv.c
+++ b/lib/nghttp3_conv.c
@@ -63,7 +63,7 @@ int64_t nghttp3_get_varint(size_t *plen, const uint8_t *p) {
 
 int64_t nghttp3_get_varint_fb(const uint8_t *p) { return *p & 0x3f; }
 
-size_t nghttp3_get_varint_len(const uint8_t *p) { return 1u << (*p >> 6); }
+size_t nghttp3_get_varintlen(const uint8_t *p) { return 1u << (*p >> 6); }
 
 uint8_t *nghttp3_put_uint64be(uint8_t *p, uint64_t n) {
   n = nghttp3_htonl64(n);
@@ -102,7 +102,7 @@ uint8_t *nghttp3_put_varint(uint8_t *p, int64_t n) {
   return rv;
 }
 
-size_t nghttp3_put_varint_len(int64_t n) {
+size_t nghttp3_put_varintlen(int64_t n) {
   if (n < 64) {
     return 1;
   }

--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -137,10 +137,10 @@ int64_t nghttp3_get_varint(size_t *plen, const uint8_t *p);
 int64_t nghttp3_get_varint_fb(const uint8_t *p);
 
 /*
- * nghttp3_get_varint_len returns the required number of bytes to read
+ * nghttp3_get_varintlen returns the required number of bytes to read
  * variable-length integer starting at |p|.
  */
-size_t nghttp3_get_varint_len(const uint8_t *p);
+size_t nghttp3_get_varintlen(const uint8_t *p);
 
 /*
  * nghttp3_put_uint64be writes |n| in host byte order in |p| in
@@ -170,10 +170,10 @@ uint8_t *nghttp3_put_uint16be(uint8_t *p, uint16_t n);
 uint8_t *nghttp3_put_varint(uint8_t *p, int64_t n);
 
 /*
- * nghttp3_put_varint_len returns the required number of bytes to
+ * nghttp3_put_varintlen returns the required number of bytes to
  * encode |n|.
  */
-size_t nghttp3_put_varint_len(int64_t n);
+size_t nghttp3_put_varintlen(int64_t n);
 
 /*
  * nghttp3_ord_stream_id returns the ordinal number of |stream_id|.

--- a/lib/nghttp3_frame.c
+++ b/lib/nghttp3_frame.c
@@ -38,7 +38,7 @@ uint8_t *nghttp3_frame_write_hd(uint8_t *p, const nghttp3_frame_hd *hd) {
 }
 
 size_t nghttp3_frame_write_hd_len(const nghttp3_frame_hd *hd) {
-  return nghttp3_put_varint_len(hd->type) + nghttp3_put_varint_len(hd->length);
+  return nghttp3_put_varintlen(hd->type) + nghttp3_put_varintlen(hd->length);
 }
 
 uint8_t *nghttp3_frame_write_settings(uint8_t *p,
@@ -61,14 +61,14 @@ size_t nghttp3_frame_write_settings_len(int64_t *ppayloadlen,
   size_t i;
 
   for (i = 0; i < fr->niv; ++i) {
-    payloadlen += nghttp3_put_varint_len((int64_t)fr->iv[i].id) +
-                  nghttp3_put_varint_len((int64_t)fr->iv[i].value);
+    payloadlen += nghttp3_put_varintlen((int64_t)fr->iv[i].id) +
+                  nghttp3_put_varintlen((int64_t)fr->iv[i].value);
   }
 
   *ppayloadlen = (int64_t)payloadlen;
 
-  return nghttp3_put_varint_len(NGHTTP3_FRAME_SETTINGS) +
-         nghttp3_put_varint_len((int64_t)payloadlen) + payloadlen;
+  return nghttp3_put_varintlen(NGHTTP3_FRAME_SETTINGS) +
+         nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
 uint8_t *nghttp3_frame_write_goaway(uint8_t *p,
@@ -81,12 +81,12 @@ uint8_t *nghttp3_frame_write_goaway(uint8_t *p,
 
 size_t nghttp3_frame_write_goaway_len(int64_t *ppayloadlen,
                                       const nghttp3_frame_goaway *fr) {
-  size_t payloadlen = nghttp3_put_varint_len(fr->id);
+  size_t payloadlen = nghttp3_put_varintlen(fr->id);
 
   *ppayloadlen = (int64_t)payloadlen;
 
-  return nghttp3_put_varint_len(NGHTTP3_FRAME_GOAWAY) +
-         nghttp3_put_varint_len((int64_t)payloadlen) + payloadlen;
+  return nghttp3_put_varintlen(NGHTTP3_FRAME_GOAWAY) +
+         nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
 uint8_t *
@@ -112,13 +112,13 @@ nghttp3_frame_write_priority_update(uint8_t *p,
 
 size_t nghttp3_frame_write_priority_update_len(
     int64_t *ppayloadlen, const nghttp3_frame_priority_update *fr) {
-  size_t payloadlen = nghttp3_put_varint_len(fr->pri_elem_id) + sizeof("u=U") -
+  size_t payloadlen = nghttp3_put_varintlen(fr->pri_elem_id) + sizeof("u=U") -
                       1 + (fr->pri.inc ? sizeof(", i") - 1 : 0);
 
   *ppayloadlen = (int64_t)payloadlen;
 
-  return nghttp3_put_varint_len(fr->hd.type) +
-         nghttp3_put_varint_len((int64_t)payloadlen) + payloadlen;
+  return nghttp3_put_varintlen(fr->hd.type) +
+         nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
 int nghttp3_nva_copy(nghttp3_nv **pnva, const nghttp3_nv *nva, size_t nvlen,

--- a/lib/nghttp3_stream.c
+++ b/lib/nghttp3_stream.c
@@ -185,7 +185,7 @@ nghttp3_ssize nghttp3_read_varint(nghttp3_varint_read_state *rvint,
   if (rvint->left == 0) {
     assert(rvint->acc == 0);
 
-    rvint->left = nghttp3_get_varint_len(src);
+    rvint->left = nghttp3_get_varintlen(src);
     if (rvint->left <= srclen) {
       rvint->acc = nghttp3_get_varint(&nread, src);
       rvint->left = 0;
@@ -305,7 +305,7 @@ static void typed_buf_shared_init(nghttp3_typed_buf *tbuf,
 }
 
 int nghttp3_stream_write_stream_type(nghttp3_stream *stream) {
-  size_t len = nghttp3_put_varint_len((int64_t)stream->type);
+  size_t len = nghttp3_put_varintlen((int64_t)stream->type);
   nghttp3_buf *chunk;
   nghttp3_typed_buf tbuf;
   int rv;


### PR DESCRIPTION
Rename nghttp3_get_varint_len and nghttp3_put_varint_len to nghttp3_get_varintlen and nghttp3_put_varintlen respectively.