### PR TITLE
add casts to silence implicit conversion warnings

### DIFF
--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -106,9 +106,9 @@ STIN uint16_t htons(uint16_t hostshort) {
 STIN uint32_t ntohl(uint32_t netlong) {
   uint32_t res;
   unsigned char *p = (unsigned char *)&netlong;
-  res = *p++ << 24;
-  res += *p++ << 16;
-  res += *p++ << 8;
+  res = (uint32_t)(*p++ << 24);
+  res += (uint32_t)(*p++ << 16);
+  res += (uint32_t)(*p++ << 8);
   res += *p;
   return res;
 }
@@ -116,7 +116,7 @@ STIN uint32_t ntohl(uint32_t netlong) {
 STIN uint16_t ntohs(uint16_t netshort) {
   uint16_t res;
   unsigned char *p = (unsigned char *)&netshort;
-  res = *p++ << 8;
+  res = (uint16_t)(*p++ << 8);
   res += *p;
   return res;
 }


### PR DESCRIPTION
Identical patch to the ones merged earlier to ngtcp2 and nghttp2:
https://github.com/ngtcp2/ngtcp2/pull/601
https://github.com/nghttp2/nghttp2/pull/1822
