### PR TITLE
Allow application to specify which field should be indexed by QPACK

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -723,6 +723,16 @@ NGHTTP3_EXTERN void nghttp3_buf_reset(nghttp3_buf *buf);
 #define NGHTTP3_NV_FLAG_NO_COPY_VALUE 0x04u
 
 /**
+ * @macro
+ *
+ * :macro:`NGHTTP3_NV_FLAG_TRY_INDEX` gives a hint to QPACK encoder to
+ * index a header field which is not indexed by default.  This is just
+ * a hint, and QPACK encoder might not encode the field in various
+ * reasons.
+ */
+#define NGHTTP3_NV_FLAG_TRY_INDEX 0x08u
+
+/**
  * @struct
  *
  * :type:`nghttp3_nv` is the name/value pair, which mainly used to

--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -1282,6 +1282,19 @@ int nghttp3_qpack_encoder_stream_is_blocked(nghttp3_qpack_encoder *encoder,
   return stream && encoder->krcnt < nghttp3_qpack_stream_get_max_cnt(stream);
 }
 
+static uint32_t qpack_hash_name(const nghttp3_nv *nv) {
+  /* 32 bit FNV-1a: http://isthe.com/chongo/tech/comp/fnv/ */
+  uint32_t h = 2166136261u;
+  size_t i;
+
+  for (i = 0; i < nv->namelen; ++i) {
+    h ^= nv->name[i];
+    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24);
+  }
+
+  return h;
+}
+
 /*
  * qpack_encoder_decide_indexing_mode determines and returns indexing
  * mode for header field |nv|.  |token| is a token of header field
@@ -1311,6 +1324,10 @@ qpack_encoder_decide_indexing_mode(nghttp3_qpack_encoder *encoder,
   case NGHTTP3_QPACK_TOKEN_IF_NONE_MATCH:
   case NGHTTP3_QPACK_TOKEN_LOCATION:
   case NGHTTP3_QPACK_TOKEN_SET_COOKIE:
+    if (nv->flags & NGHTTP3_NV_FLAG_TRY_INDEX) {
+      break;
+    }
+
     return NGHTTP3_QPACK_INDEXING_MODE_LITERAL;
   case NGHTTP3_QPACK_TOKEN_HOST:
   case NGHTTP3_QPACK_TOKEN_TE:
@@ -1318,6 +1335,10 @@ qpack_encoder_decide_indexing_mode(nghttp3_qpack_encoder *encoder,
   case NGHTTP3_QPACK_TOKEN_PRIORITY:
     break;
   default:
+    if (nv->flags & NGHTTP3_NV_FLAG_TRY_INDEX) {
+      break;
+    }
+
     if (token >= 1000) {
       return NGHTTP3_QPACK_INDEXING_MODE_LITERAL;
     }
@@ -1445,6 +1466,8 @@ int nghttp3_qpack_encoder_encode_nv(nghttp3_qpack_encoder *encoder,
     case NGHTTP3_QPACK_TOKEN_PRIORITY:
       hash = 2498028297u;
       break;
+    default:
+      hash = qpack_hash_name(nv);
     }
   }
 
@@ -1458,8 +1481,7 @@ int nghttp3_qpack_encoder_encode_nv(nghttp3_qpack_encoder *encoder,
     }
   }
 
-  if (hash &&
-      nghttp3_map_size(&encoder->streams) < NGHTTP3_QPACK_MAX_QPACK_STREAMS) {
+  if (nghttp3_map_size(&encoder->streams) < NGHTTP3_QPACK_MAX_QPACK_STREAMS) {
     dres = nghttp3_qpack_encoder_lookup_dtable(encoder, nv, token, hash,
                                                indexing_mode, encoder->krcnt,
                                                allow_blocking);

--- a/tests/main.c
+++ b/tests/main.c
@@ -60,6 +60,8 @@ int main(void) {
   /* add the tests to the suite */
   if (!CU_add_test(pSuite, "qpack_encoder_encode",
                    test_nghttp3_qpack_encoder_encode) ||
+      !CU_add_test(pSuite, "qpack_encoder_encode_try_encode",
+                   test_nghttp3_qpack_encoder_encode_try_encode) ||
       !CU_add_test(pSuite, "qpack_encoder_still_blocked",
                    test_nghttp3_qpack_encoder_still_blocked) ||
       !CU_add_test(pSuite, "qpack_encoder_set_dtable_cap",

--- a/tests/nghttp3_qpack_test.h
+++ b/tests/nghttp3_qpack_test.h
@@ -30,6 +30,7 @@
 #endif /* HAVE_CONFIG_H */
 
 void test_nghttp3_qpack_encoder_encode(void);
+void test_nghttp3_qpack_encoder_encode_try_encode(void);
 void test_nghttp3_qpack_encoder_still_blocked(void);
 void test_nghttp3_qpack_encoder_set_dtable_cap(void);
 void test_nghttp3_qpack_decoder_feedback(void);


### PR DESCRIPTION
Allow application to specify which field should be indexed by including NGHTTP3_NV_FLAG_TRY_INDEX in nghttp3_nv.flags.  This is just a hint, and QPACK encoder might not index it in various reasons.

Fixes #100 