### PR TITLE
Increase stream outq capacity

### DIFF
--- a/lib/nghttp3_stream.c
+++ b/lib/nghttp3_stream.c
@@ -690,7 +690,7 @@ int nghttp3_stream_write_qpack_decoder_stream(nghttp3_stream *stream) {
 
 int nghttp3_stream_outq_is_full(nghttp3_stream *stream) {
   /* TODO Verify that the limit is reasonable. */
-  return nghttp3_ringbuf_len(&stream->outq) >= 1024;
+  return nghttp3_ringbuf_len(&stream->outq) >= 2048;
 }
 
 int nghttp3_stream_outq_add(nghttp3_stream *stream,


### PR DESCRIPTION
Increase stream outq capacity because the previous value is too small for high latency network.  As the comment suggests, we should provide a knob for an application to set this limit.