### PR TITLE
Remove stream outq limit

### DIFF
--- a/lib/nghttp3_stream.c
+++ b/lib/nghttp3_stream.c
@@ -245,7 +245,7 @@ int nghttp3_stream_fill_outq(nghttp3_stream *stream) {
   int data_eof;
   int rv;
 
-  for (; nghttp3_ringbuf_len(frq) && !nghttp3_stream_outq_is_full(stream) &&
+  for (; nghttp3_ringbuf_len(frq) &&
          stream->unsent_bytes < NGHTTP3_MIN_UNSENT_BYTES;) {
     frent = nghttp3_ringbuf_get(frq, 0);
 
@@ -686,11 +686,6 @@ int nghttp3_stream_write_qpack_decoder_stream(nghttp3_stream *stream) {
   tbuf.buf.last = chunk->last;
 
   return nghttp3_stream_outq_add(stream, &tbuf);
-}
-
-int nghttp3_stream_outq_is_full(nghttp3_stream *stream) {
-  /* TODO Verify that the limit is reasonable. */
-  return nghttp3_ringbuf_len(&stream->outq) >= 2048;
 }
 
 int nghttp3_stream_outq_add(nghttp3_stream *stream,

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -298,8 +298,6 @@ nghttp3_ssize nghttp3_stream_writev(nghttp3_stream *stream, int *pfin,
 
 int nghttp3_stream_write_qpack_decoder_stream(nghttp3_stream *stream);
 
-int nghttp3_stream_outq_is_full(nghttp3_stream *stream);
-
 int nghttp3_stream_outq_add(nghttp3_stream *stream,
                             const nghttp3_typed_buf *tbuf);
 


### PR DESCRIPTION
Remove stream outq limit by the library.  Instead, let an application manage the amount of buffer they can burn because the most of the items in outq is data provided by the application.  For example, the application can track the number of bytes it has provided to the library in nghttp3_read_data_callback.  If it exceeds the limit, return NGHTTP3_ERR_WOULDBLOCK from the callback.  The tracked bytes should be updated when the data is acknowledged (see nghttp3_acked_stream_data callback).