### PR TITLE
Rework priority interface

### DIFF
--- a/doc/mkapiref.py
+++ b/doc/mkapiref.py
@@ -293,7 +293,7 @@ def process_function(domain, infile):
         else:
             func_proto.append(line)
     func_proto = ''.join(func_proto)
-    func_proto = re.sub(r'int (settings|callbacks)_version,',
+    func_proto = re.sub(r'int (settings|callbacks|pri)_version,',
                         '', func_proto)
     func_proto = re.sub(r'_versioned\(', '(', func_proto)
     func_proto = re.sub(r';\n$', '', func_proto)

--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -68,6 +68,12 @@ extern "C" {
 #  endif /* !BUILDING_NGHTTP3 */
 #endif   /* !defined(WIN32) */
 
+#ifdef _MSC_VER
+#  define NGHTTP3_ALIGN(N) __declspec(align(N))
+#else /* !_MSC_VER */
+#  define NGHTTP3_ALIGN(N) __attribute__((aligned(N)))
+#endif /* !_MSC_VER */
+
 /**
  * @typedef
  *
@@ -2431,12 +2437,15 @@ NGHTTP3_EXTERN uint64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
  */
 #define NGHTTP3_URGENCY_LEVELS (NGHTTP3_URGENCY_LOW + 1)
 
+#define NGHTTP3_PRI_V1 1
+#define NGHTTP3_PRI_VERSION NGHTTP3_PRI_V1
+
 /**
  * @struct
  *
  * :type:`nghttp3_pri` represents HTTP priority.
  */
-typedef struct nghttp3_pri {
+typedef struct NGHTTP3_ALIGN(8) nghttp3_pri {
   /**
    * :member:`urgency` is the urgency of a stream, it must be in
    * [:macro:`NGHTTP3_URGENCY_HIGH`, :macro:`NGHTTP3_URGENCY_LOW`],
@@ -2466,26 +2475,25 @@ typedef struct nghttp3_pri {
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
+ * :macro:`NGHTTP3_ERR_INVALID_ARGUMENT`
+ *     |stream_id| is not a client initiated bidirectional stream ID.
  * :macro:`NGHTTP3_ERR_STREAM_NOT_FOUND`
  *     Stream not found.
  */
-NGHTTP3_EXTERN int nghttp3_conn_get_stream_priority(nghttp3_conn *conn,
-                                                    nghttp3_pri *dest,
-                                                    int64_t stream_id);
+NGHTTP3_EXTERN int nghttp3_conn_get_stream_priority_versioned(
+    nghttp3_conn *conn, int pri_version, nghttp3_pri *dest, int64_t stream_id);
 
 /**
  * @function
  *
- * `nghttp3_conn_set_stream_priority` updates priority of a stream
- * denoted by |stream_id| with the value pointed by |pri|.
- * |stream_id| must identify client initiated bidirectional stream.
+ * `nghttp3_conn_set_client_stream_priority` updates priority of a
+ * stream denoted by |stream_id| with the value pointed by |data| of
+ * length |datalen|, which should be a serialized :rfc:`9218` priority
+ * field value.  |stream_id| must identify client initiated
+ * bidirectional stream.
  *
- * Both client and server can update stream priority with this
- * function.
- *
- * If server updates stream priority with this function, it completely
- * overrides stream priority set by client and the attempts to update
- * priority by client are ignored.
+ * This function must not be called if |conn| is initialized as
+ * server.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
@@ -2497,9 +2505,37 @@ NGHTTP3_EXTERN int nghttp3_conn_get_stream_priority(nghttp3_conn *conn,
  * :macro:`NGHTTP3_ERR_NOMEM`
  *     Out of memory.
  */
-NGHTTP3_EXTERN int nghttp3_conn_set_stream_priority(nghttp3_conn *conn,
-                                                    int64_t stream_id,
-                                                    const nghttp3_pri *pri);
+NGHTTP3_EXTERN int nghttp3_conn_set_client_stream_priority(nghttp3_conn *conn,
+                                                           int64_t stream_id,
+                                                           const uint8_t *data,
+                                                           size_t datalen);
+
+/**
+ * @function
+ *
+ * `nghttp3_conn_set_server_stream_priority` updates priority of a
+ * stream denoted by |stream_id| with the value pointed by |pri|.
+ * |stream_id| must identify client initiated bidirectional stream.
+ *
+ * This function must not be called if |conn| is initialized as
+ * client.
+ *
+ * This function completely overrides stream priority set by client
+ * and the attempts to update priority by client are ignored.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGHTTP3_ERR_INVALID_ARGUMENT`
+ *     |stream_id| is not a client initiated bidirectional stream ID.
+ * :macro:`NGHTTP3_ERR_STREAM_NOT_FOUND`
+ *     Stream not found.
+ * :macro:`NGHTTP3_ERR_NOMEM`
+ *     Out of memory.
+ */
+NGHTTP3_EXTERN int nghttp3_conn_set_server_stream_priority_versioned(
+    nghttp3_conn *conn, int64_t stream_id, int pri_version,
+    const nghttp3_pri *pri);
 
 /**
  * @function
@@ -2540,25 +2576,6 @@ NGHTTP3_EXTERN int nghttp3_check_header_name(const uint8_t *name, size_t len);
  * :rfc:`7230#section-3.2`.
  */
 NGHTTP3_EXTERN int nghttp3_check_header_value(const uint8_t *value, size_t len);
-
-/**
- * @function
- *
- * `nghttp3_http_parse_priority` parses priority HTTP header field
- * stored in the buffer pointed by |value| of length |len|.  If it
- * successfully processed header field value, it stores the result
- * into |*dest|.  This function just overwrites what it sees in the
- * header field value and does not initialize any field in |*dest|.
- *
- * This function returns 0 if it succeeds, or one of the following
- * negative error codes:
- *
- * :macro:`NGHTTP3_ERR_INVALID_ARGUMENT`
- *     The function could not parse the provided value.
- */
-NGHTTP3_EXTERN int nghttp3_http_parse_priority(nghttp3_pri *dest,
-                                               const uint8_t *value,
-                                               size_t len);
 
 /**
  * @function
@@ -2661,6 +2678,24 @@ NGHTTP3_EXTERN int nghttp3_err_is_fatal(int liberr);
   nghttp3_conn_server_new_versioned((PCONN), NGHTTP3_CALLBACKS_VERSION,        \
                                     (CALLBACKS), NGHTTP3_SETTINGS_VERSION,     \
                                     (SETTINGS), (MEM), (USER_DATA))
+
+/*
+ * `nghttp3_conn_set_server_stream_priority` is a wrapper around
+ * `nghttp3_conn_set_server_stream_priority_versioned` to set the
+ * correct struct version.
+ */
+#define nghttp3_conn_set_server_stream_priority(CONN, STREAM_ID, PRI)          \
+  nghttp3_conn_set_server_stream_priority_versioned(                           \
+      (CONN), (STREAM_ID), NGHTTP3_PRI_VERSION, (PRI))
+
+/*
+ * `nghttp3_conn_get_stream_priority` is a wrapper around
+ * `nghttp3_conn_get_stream_priority_versioned` to set the correct
+ * struct version.
+ */
+#define nghttp3_conn_get_stream_priority(CONN, DEST, STREAM_ID)                \
+  nghttp3_conn_get_stream_priority_versioned((CONN), NGHTTP3_PRI_VERSION,      \
+                                             (DEST), (STREAM_ID))
 
 #ifdef __cplusplus
 }

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -1146,16 +1146,17 @@ static nghttp3_tnode *stream_get_sched_node(nghttp3_stream *stream) {
 }
 
 static int conn_update_stream_priority(nghttp3_conn *conn,
-                                       nghttp3_stream *stream, uint8_t pri) {
+                                       nghttp3_stream *stream,
+                                       const nghttp3_pri *pri) {
   assert(nghttp3_client_stream_bidi(stream->node.id));
 
-  if (stream->node.pri == pri) {
+  if (nghttp3_pri_eq(&stream->node.pri, pri)) {
     return 0;
   }
 
   nghttp3_conn_unschedule_stream(conn, stream);
 
-  stream->node.pri = pri;
+  stream->node.pri = *pri;
 
   if (nghttp3_stream_require_schedule(stream)) {
     return nghttp3_conn_schedule_stream(conn, stream);
@@ -1392,7 +1393,7 @@ nghttp3_ssize nghttp3_conn_read_bidi(nghttp3_conn *conn, size_t *pnproc,
             (stream->rx.http.flags & NGHTTP3_HTTP_FLAG_PRIORITY) &&
             !(stream->flags & NGHTTP3_STREAM_FLAG_PRIORITY_UPDATE_RECVED) &&
             !(stream->flags & NGHTTP3_STREAM_FLAG_SERVER_PRIORITY_SET)) {
-          rv = conn_update_stream_priority(conn, stream, stream->rx.http.pri);
+          rv = conn_update_stream_priority(conn, stream, &stream->rx.http.pri);
           if (rv != 0) {
             return rv;
           }
@@ -1508,11 +1509,9 @@ int nghttp3_conn_on_data(nghttp3_conn *conn, nghttp3_stream *stream,
 }
 
 static nghttp3_pq *conn_get_sched_pq(nghttp3_conn *conn, nghttp3_tnode *tnode) {
-  uint32_t urgency = nghttp3_pri_uint8_urgency(tnode->pri);
+  assert(tnode->pri.urgency < NGHTTP3_URGENCY_LEVELS);
 
-  assert(urgency < NGHTTP3_URGENCY_LEVELS);
-
-  return &conn->sched[urgency].spq;
+  return &conn->sched[tnode->pri.urgency].spq;
 }
 
 static nghttp3_ssize conn_decode_headers(nghttp3_conn *conn,
@@ -1753,7 +1752,7 @@ conn_on_priority_update_stream(nghttp3_conn *conn,
       return rv;
     }
 
-    stream->node.pri = nghttp3_pri_to_uint8(&fr->pri);
+    stream->node.pri = fr->pri;
     stream->flags |= NGHTTP3_STREAM_FLAG_PRIORITY_UPDATE_RECVED;
 
     return 0;
@@ -1765,8 +1764,7 @@ conn_on_priority_update_stream(nghttp3_conn *conn,
 
   stream->flags |= NGHTTP3_STREAM_FLAG_PRIORITY_UPDATE_RECVED;
 
-  return conn_update_stream_priority(conn, stream,
-                                     nghttp3_pri_to_uint8(&fr->pri));
+  return conn_update_stream_priority(conn, stream, &fr->pri);
 }
 
 int nghttp3_conn_on_priority_update(nghttp3_conn *conn,
@@ -2480,9 +2478,12 @@ uint64_t nghttp3_conn_get_frame_payload_left(nghttp3_conn *conn,
   return (uint64_t)stream->rstate.left;
 }
 
-int nghttp3_conn_get_stream_priority(nghttp3_conn *conn, nghttp3_pri *dest,
-                                     int64_t stream_id) {
+int nghttp3_conn_get_stream_priority_versioned(nghttp3_conn *conn,
+                                               int pri_version,
+                                               nghttp3_pri *dest,
+                                               int64_t stream_id) {
   nghttp3_stream *stream;
+  (void)pri_version;
 
   assert(conn->server);
 
@@ -2495,17 +2496,55 @@ int nghttp3_conn_get_stream_priority(nghttp3_conn *conn, nghttp3_pri *dest,
     return NGHTTP3_ERR_STREAM_NOT_FOUND;
   }
 
-  dest->urgency = nghttp3_pri_uint8_urgency(stream->node.pri);
-  dest->inc = nghttp3_pri_uint8_inc(stream->node.pri);
+  *dest = stream->node.pri;
 
   return 0;
 }
 
-int nghttp3_conn_set_stream_priority(nghttp3_conn *conn, int64_t stream_id,
-                                     const nghttp3_pri *pri) {
+int nghttp3_conn_set_client_stream_priority(nghttp3_conn *conn,
+                                            int64_t stream_id,
+                                            const uint8_t *data,
+                                            size_t datalen) {
   nghttp3_stream *stream;
   nghttp3_frame_entry frent;
+  uint8_t *buf = NULL;
 
+  assert(!conn->server);
+
+  if (!nghttp3_client_stream_bidi(stream_id)) {
+    return NGHTTP3_ERR_INVALID_ARGUMENT;
+  }
+
+  stream = nghttp3_conn_find_stream(conn, stream_id);
+  if (stream == NULL) {
+    return NGHTTP3_ERR_STREAM_NOT_FOUND;
+  }
+
+  if (datalen) {
+    buf = nghttp3_mem_malloc(conn->mem, datalen);
+    if (buf == NULL) {
+      return NGHTTP3_ERR_NOMEM;
+    }
+
+    memcpy(buf, data, datalen);
+  }
+
+  frent.fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  frent.fr.priority_update.pri_elem_id = stream_id;
+  frent.fr.priority_update.data = buf;
+  frent.fr.priority_update.datalen = datalen;
+
+  return nghttp3_stream_frq_add(conn->tx.ctrl, &frent);
+}
+
+int nghttp3_conn_set_server_stream_priority_versioned(nghttp3_conn *conn,
+                                                      int64_t stream_id,
+                                                      int pri_version,
+                                                      const nghttp3_pri *pri) {
+  nghttp3_stream *stream;
+  (void)pri_version;
+
+  assert(conn->server);
   assert(pri->urgency < NGHTTP3_URGENCY_LEVELS);
   assert(pri->inc == 0 || pri->inc == 1);
 
@@ -2518,17 +2557,9 @@ int nghttp3_conn_set_stream_priority(nghttp3_conn *conn, int64_t stream_id,
     return NGHTTP3_ERR_STREAM_NOT_FOUND;
   }
 
-  if (conn->server) {
-    stream->flags |= NGHTTP3_STREAM_FLAG_SERVER_PRIORITY_SET;
+  stream->flags |= NGHTTP3_STREAM_FLAG_SERVER_PRIORITY_SET;
 
-    return conn_update_stream_priority(conn, stream, nghttp3_pri_to_uint8(pri));
-  }
-
-  frent.fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
-  frent.fr.priority_update.pri_elem_id = stream_id;
-  frent.fr.priority_update.pri = *pri;
-
-  return nghttp3_stream_frq_add(conn->tx.ctrl, &frent);
+  return conn_update_stream_priority(conn, stream, pri);
 }
 
 int nghttp3_conn_is_remote_qpack_encoder_stream(nghttp3_conn *conn,

--- a/lib/nghttp3_conv.c
+++ b/lib/nghttp3_conv.c
@@ -119,7 +119,3 @@ size_t nghttp3_put_varintlen(int64_t n) {
 uint64_t nghttp3_ord_stream_id(int64_t stream_id) {
   return (uint64_t)(stream_id >> 2) + 1;
 }
-
-uint8_t nghttp3_pri_to_uint8(const nghttp3_pri *pri) {
-  return (uint8_t)((uint32_t)pri->inc << 7 | pri->urgency);
-}

--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -186,22 +186,4 @@ uint64_t nghttp3_ord_stream_id(int64_t stream_id);
  */
 #define NGHTTP3_PRI_INC_MASK (1 << 7)
 
-/*
- * nghttp3_pri_to_uint8 encodes |pri| into uint8_t variable.
- */
-uint8_t nghttp3_pri_to_uint8(const nghttp3_pri *pri);
-
-/*
- * nghttp3_pri_uint8_urgency extracts urgency from |PRI| which is
- * supposed to be constructed by nghttp3_pri_to_uint8.
- */
-#define nghttp3_pri_uint8_urgency(PRI)                                         \
-  ((uint32_t)((PRI) & ~NGHTTP3_PRI_INC_MASK))
-
-/*
- * nghttp3_pri_uint8_inc extracts inc from |PRI| which is supposed to
- * be constructed by nghttp3_pri_to_uint8.
- */
-#define nghttp3_pri_uint8_inc(PRI) (((PRI)&NGHTTP3_PRI_INC_MASK) != 0)
-
 #endif /* NGHTTP3_CONV_H */

--- a/lib/nghttp3_frame.h
+++ b/lib/nghttp3_frame.h
@@ -103,7 +103,17 @@ typedef struct nghttp3_frame_priority_update {
      NGHTTP3_FRAME_PRIORITY_UPDATE_PUSH_ID.  It is undefined
      otherwise. */
   int64_t pri_elem_id;
-  nghttp3_pri pri;
+  /* When sending this frame, data should point to the buffer
+     containing a serialized priority field value and its length is
+     set to datalen.  On reception, pri contains the decoded priority
+     header value. */
+  union {
+    nghttp3_pri pri;
+    struct {
+      uint8_t *data;
+      size_t datalen;
+    };
+  };
 } nghttp3_frame_priority_update;
 
 typedef union nghttp3_frame {
@@ -211,5 +221,12 @@ void nghttp3_nva_del(nghttp3_nv *nva, const nghttp3_mem *mem);
  */
 void nghttp3_frame_headers_free(nghttp3_frame_headers *fr,
                                 const nghttp3_mem *mem);
+
+/*
+ * nghttp3_frame_priority_update_free frees memory allocated for |fr|.
+ * This function should only be called for an outgoing frame.
+ */
+void nghttp3_frame_priority_update_free(nghttp3_frame_priority_update *fr,
+                                        const nghttp3_mem *mem);
 
 #endif /* NGHTTP3_FRAME_H */

--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -277,11 +277,10 @@ static int http_request_on_header(nghttp3_http_state *http,
     break;
   case NGHTTP3_QPACK_TOKEN_PRIORITY:
     if (!trailers && !(http->flags & NGHTTP3_HTTP_FLAG_BAD_PRIORITY)) {
-      pri.urgency = nghttp3_pri_uint8_urgency(http->pri);
-      pri.inc = nghttp3_pri_uint8_inc(http->pri);
+      pri = http->pri;
       if (nghttp3_http_parse_priority(&pri, nv->value->base, nv->value->len) ==
           0) {
-        http->pri = nghttp3_pri_to_uint8(&pri);
+        http->pri = pri;
         http->flags |= NGHTTP3_HTTP_FLAG_PRIORITY;
       } else {
         http->flags &= ~NGHTTP3_HTTP_FLAG_PRIORITY;
@@ -996,4 +995,8 @@ int nghttp3_check_header_value(const uint8_t *value, size_t len) {
     }
   }
   return 1;
+}
+
+int nghttp3_pri_eq(const nghttp3_pri *a, const nghttp3_pri *b) {
+  return a->urgency == b->urgency && a->inc == b->inc;
 }

--- a/lib/nghttp3_http.h
+++ b/lib/nghttp3_http.h
@@ -150,4 +150,24 @@ int nghttp3_http_on_data_chunk(nghttp3_stream *stream, size_t n);
 void nghttp3_http_record_request_method(nghttp3_stream *stream,
                                         const nghttp3_nv *nva, size_t nvlen);
 
+/**
+ * @function
+ *
+ * `nghttp3_http_parse_priority` parses priority HTTP header field
+ * stored in the buffer pointed by |value| of length |len|.  If it
+ * successfully processed header field value, it stores the result
+ * into |*dest|.  This function just overwrites what it sees in the
+ * header field value and does not initialize any field in |*dest|.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :macro:`NGHTTP3_ERR_INVALID_ARGUMENT`
+ *     The function could not parse the provided value.
+ */
+int nghttp3_http_parse_priority(nghttp3_pri *dest, const uint8_t *value,
+                                size_t len);
+
+int nghttp3_pri_eq(const nghttp3_pri *a, const nghttp3_pri *b);
+
 #endif /* NGHTTP3_HTTP_H */

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -195,9 +195,8 @@ typedef struct nghttp3_http_state {
   /* recv_content_length is the number of body bytes received so
      far. */
   int64_t recv_content_length;
+  nghttp3_pri pri;
   uint32_t flags;
-  /* pri is a stream priority produced by nghttp3_pri_to_uint8. */
-  uint8_t pri;
 } nghttp3_http_state;
 
 struct nghttp3_stream {

--- a/lib/nghttp3_tnode.h
+++ b/lib/nghttp3_tnode.h
@@ -41,10 +41,10 @@ typedef struct nghttp3_tnode {
   int64_t id;
   uint64_t cycle;
   /* pri is a stream priority produced by nghttp3_pri_to_uint8. */
-  uint8_t pri;
+  nghttp3_pri pri;
 } nghttp3_tnode;
 
-void nghttp3_tnode_init(nghttp3_tnode *tnode, int64_t id, uint8_t pri);
+void nghttp3_tnode_init(nghttp3_tnode *tnode, int64_t id);
 
 void nghttp3_tnode_free(nghttp3_tnode *tnode);
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -125,8 +125,7 @@ int main(void) {
       !CU_add_test(pSuite, "http_parse_priority",
                    test_nghttp3_http_parse_priority) ||
       !CU_add_test(pSuite, "check_header_value",
-                   test_nghttp3_check_header_value) ||
-      !CU_add_test(pSuite, "pri_to_uint8", test_nghttp3_pri_to_uint8)) {
+                   test_nghttp3_check_header_value)) {
     CU_cleanup_registry();
     return (int)CU_get_error();
   }

--- a/tests/nghttp3_conv_test.c
+++ b/tests/nghttp3_conv_test.c
@@ -30,22 +30,3 @@
 
 #include "nghttp3_conv.h"
 #include "nghttp3_test_helper.h"
-
-void test_nghttp3_pri_to_uint8(void) {
-  {
-    nghttp3_pri pri = {1, 0};
-    CU_ASSERT(1 == nghttp3_pri_to_uint8(&pri));
-  }
-  {
-    nghttp3_pri pri = {1, 1};
-    CU_ASSERT((0x80 | 1) == nghttp3_pri_to_uint8(&pri));
-  }
-  {
-    nghttp3_pri pri = {7, 1};
-    CU_ASSERT((0x80 | 7) == nghttp3_pri_to_uint8(&pri));
-  }
-  {
-    nghttp3_pri pri = {7, 0};
-    CU_ASSERT(7 == nghttp3_pri_to_uint8(&pri));
-  }
-}

--- a/tests/nghttp3_conv_test.h
+++ b/tests/nghttp3_conv_test.h
@@ -29,6 +29,4 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-void test_nghttp3_pri_to_uint8(void);
-
 #endif /* NGTCP2_CONV_TEST_H */

--- a/tests/nghttp3_tnode_test.c
+++ b/tests/nghttp3_tnode_test.c
@@ -51,7 +51,8 @@ void test_nghttp3_tnode_schedule(void) {
   nghttp3_tnode *p;
 
   /* Schedule node with incremental enabled */
-  nghttp3_tnode_init(&node, 0, (1 << 7) | NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node, 0);
+  node.pri.inc = 1;
 
   nghttp3_pq_init(&pq, cycle_less, mem);
 
@@ -61,7 +62,8 @@ void test_nghttp3_tnode_schedule(void) {
   CU_ASSERT(0 == node.cycle);
 
   /* Schedule another node */
-  nghttp3_tnode_init(&node2, 1, (1 << 7) | NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node2, 1);
+  node.pri.inc = 1;
 
   rv = nghttp3_tnode_schedule(&node2, &pq, 0);
 
@@ -84,7 +86,7 @@ void test_nghttp3_tnode_schedule(void) {
   nghttp3_pq_free(&pq);
 
   /* Schedule node without incremental */
-  nghttp3_tnode_init(&node, 0, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node, 0);
 
   nghttp3_pq_init(&pq, cycle_less, mem);
 
@@ -94,7 +96,7 @@ void test_nghttp3_tnode_schedule(void) {
   CU_ASSERT(0 == node.cycle);
 
   /* Schedule another node */
-  nghttp3_tnode_init(&node2, 1, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node2, 1);
 
   rv = nghttp3_tnode_schedule(&node2, &pq, 0);
 
@@ -119,13 +121,13 @@ void test_nghttp3_tnode_schedule(void) {
   /* Stream with lower stream ID takes precedence */
   nghttp3_pq_init(&pq, cycle_less, mem);
 
-  nghttp3_tnode_init(&node2, 1, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node2, 1);
 
   rv = nghttp3_tnode_schedule(&node2, &pq, 0);
 
   CU_ASSERT(0 == rv);
 
-  nghttp3_tnode_init(&node, 0, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node, 0);
 
   rv = nghttp3_tnode_schedule(&node, &pq, 0);
 
@@ -142,13 +144,13 @@ void test_nghttp3_tnode_schedule(void) {
   /* Check the same reversing push order */
   nghttp3_pq_init(&pq, cycle_less, mem);
 
-  nghttp3_tnode_init(&node, 0, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node, 0);
 
   rv = nghttp3_tnode_schedule(&node, &pq, 0);
 
   CU_ASSERT(0 == rv);
 
-  nghttp3_tnode_init(&node2, 1, NGHTTP3_DEFAULT_URGENCY);
+  nghttp3_tnode_init(&node2, 1);
 
   rv = nghttp3_tnode_schedule(&node2, &pq, 0);
 


### PR DESCRIPTION
The function that updates stream priority is now split into 2, each for client and server respectively.

nghttp3_conn_set_client_stream_priority takes a serialized form of RFC 9218 priority field value, so that client application can send extensions which nghttp3 might not understand.

nghttp3_pri is now versioned struct.

nghttp3_http_parse_priority is now hidden until we see the real needs for it.