### PR TITLE
Use uint8_t for bool fields

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -1943,12 +1943,12 @@ typedef struct nghttp3_settings {
    * Extended CONNECT Method (see :rfc:`9220`).  Client ignores this
    * field.
    */
-  int enable_connect_protocol;
+  uint8_t enable_connect_protocol;
   /**
    * :member:`h3_datagram`, if set to nonzero, enables HTTP/3
    * Datagrams (see :rfc:`9297`).
    */
-  int h3_datagram;
+  uint8_t h3_datagram;
 } nghttp3_settings;
 
 /**
@@ -2458,7 +2458,7 @@ typedef struct NGHTTP3_ALIGN(8) nghttp3_pri {
    * incrementally.  If inc is 1, it can be processed incrementally.
    * Other value is not permitted.
    */
-  int inc;
+  uint8_t inc;
 } nghttp3_pri;
 
 /**

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -1687,7 +1687,7 @@ int nghttp3_conn_on_settings_entry_received(nghttp3_conn *conn,
       return NGHTTP3_ERR_H3_SETTINGS_ERROR;
     }
 
-    dest->enable_connect_protocol = (int)ent->value;
+    dest->enable_connect_protocol = (uint8_t)ent->value;
     break;
   case NGHTTP3_SETTINGS_ID_H3_DATAGRAM:
     switch (ent->value) {
@@ -1698,7 +1698,7 @@ int nghttp3_conn_on_settings_entry_received(nghttp3_conn *conn,
       return NGHTTP3_ERR_H3_SETTINGS_ERROR;
     }
 
-    dest->h3_datagram = (int)ent->value;
+    dest->h3_datagram = (uint8_t)ent->value;
     break;
   case NGHTTP3_H2_SETTINGS_ID_ENABLE_PUSH:
   case NGHTTP3_H2_SETTINGS_ID_MAX_CONCURRENT_STREAMS:

--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -147,7 +147,7 @@ int nghttp3_http_parse_priority(nghttp3_pri *dest, const uint8_t *value,
         return NGHTTP3_ERR_INVALID_ARGUMENT;
       }
 
-      pri.inc = val.boolean;
+      pri.inc = (uint8_t)val.boolean;
 
       break;
     case 'u':

--- a/tests/nghttp3_http_test.c
+++ b/tests/nghttp3_http_test.c
@@ -37,18 +37,51 @@ void test_nghttp3_http_parse_priority(void) {
   int rv;
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
 
     CU_ASSERT(0 == rv);
     CU_ASSERT((uint32_t)-1 == pri.urgency);
-    CU_ASSERT(-1 == pri.inc);
+    CU_ASSERT(UINT8_MAX == pri.inc);
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
+    const uint8_t v[] = "u=1";
+
+    rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
+
+    CU_ASSERT(0 == rv);
+    CU_ASSERT((uint32_t)1 == pri.urgency);
+    CU_ASSERT(UINT8_MAX == pri.inc);
+  }
+
+  {
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
+    const uint8_t v[] = "i";
+
+    rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
+
+    CU_ASSERT(0 == rv);
+    CU_ASSERT((uint32_t)-1 == pri.urgency);
+    CU_ASSERT(1 == pri.inc);
+  }
+
+  {
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
+    const uint8_t v[] = "i=?0";
+
+    rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
+
+    CU_ASSERT(0 == rv);
+    CU_ASSERT((uint32_t)-1 == pri.urgency);
+    CU_ASSERT(0 == pri.inc);
+  }
+
+  {
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=7,i";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -59,7 +92,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=0,i=?0";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -70,7 +103,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=3, i";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -81,7 +114,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=0, i, i=?0, u=6";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -92,7 +125,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=0,";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -101,7 +134,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=0, ";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -110,7 +143,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -119,7 +152,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -128,7 +161,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "i=?1";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -139,7 +172,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "i=?2";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -148,7 +181,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "i=?";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -157,7 +190,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "i=";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -166,7 +199,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=-1";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -175,7 +208,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = "u=8";
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v) - 1);
@@ -184,7 +217,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] =
         "i=?0, u=1, a=(x y z), u=2; i=?0;foo=\",,,\", i=?1;i=?0; u=6";
 
@@ -196,7 +229,7 @@ void test_nghttp3_http_parse_priority(void) {
   }
 
   {
-    nghttp3_pri pri = {(uint32_t)-1, -1};
+    nghttp3_pri pri = {(uint32_t)-1, UINT8_MAX};
     const uint8_t v[] = {'u', '='};
 
     rv = nghttp3_http_parse_priority(&pri, v, sizeof(v));


### PR DESCRIPTION
Use uint8_t for bool fields to potentially reduce space.