### PR TITLE
Remove nghttp3_conn_is_remote_qpack_encoder_stream

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2728,17 +2728,6 @@ NGHTTP3_EXTERN int nghttp3_conn_set_server_stream_priority_versioned(
 /**
  * @function
  *
- * `nghttp3_conn_is_remote_qpack_encoder_stream` returns nonzero if a
- * stream denoted by |stream_id| is QPACK encoder stream of a remote
- * endpoint.
- */
-NGHTTP3_EXTERN int
-nghttp3_conn_is_remote_qpack_encoder_stream(nghttp3_conn *conn,
-                                            int64_t stream_id);
-
-/**
- * @function
- *
  * `nghttp3_vec_len` returns the sum of length in |vec| of |cnt|
  * elements.
  */

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -39,17 +39,6 @@
    dynamic table capacity that QPACK encoder is willing to use. */
 #define NGHTTP3_QPACK_ENCODER_MAX_DTABLE_CAPACITY 4096
 
-/*
- * conn_remote_stream_uni returns nonzero if |stream_id| is remote
- * unidirectional stream ID.
- */
-static int conn_remote_stream_uni(nghttp3_conn *conn, int64_t stream_id) {
-  if (conn->server) {
-    return (stream_id & 0x03) == 0x02;
-  }
-  return (stream_id & 0x03) == 0x03;
-}
-
 static int conn_call_begin_headers(nghttp3_conn *conn, nghttp3_stream *stream) {
   int rv;
 
@@ -2592,18 +2581,6 @@ int nghttp3_conn_set_server_stream_priority_versioned(nghttp3_conn *conn,
   stream->flags |= NGHTTP3_STREAM_FLAG_SERVER_PRIORITY_SET;
 
   return conn_update_stream_priority(conn, stream, pri);
-}
-
-int nghttp3_conn_is_remote_qpack_encoder_stream(nghttp3_conn *conn,
-                                                int64_t stream_id) {
-  nghttp3_stream *stream;
-
-  if (!conn_remote_stream_uni(conn, stream_id)) {
-    return 0;
-  }
-
-  stream = nghttp3_conn_find_stream(conn, stream_id);
-  return stream && stream->type == NGHTTP3_STREAM_TYPE_QPACK_ENCODER;
 }
 
 int nghttp3_conn_is_drained(nghttp3_conn *conn) {


### PR DESCRIPTION
Remove nghttp3_conn_is_remote_qpack_encoder_stream which was introduced along with nghttp3_conn_get_frame_payload_left, but not used effectively.