### PR TITLE
Fix compile error for Android/Linux - undefined symbol: nghttp3_ntohl

### DIFF
--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -74,8 +74,8 @@
 #      define nghttp3_bswap64 OSSwapInt64
 #    else /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
 #      define nghttp3_bswap64(N)                                               \
-        ((uint64_t)(nghttp3_ntohl((uint32_t)(N))) << 32 |                      \
-         nghttp3_ntohl((uint32_t)((N) >> 32)))
+        ((uint64_t)(ntohl((uint32_t)(N))) << 32 |                      \
+         ntohl((uint32_t)((N) >> 32)))
 #    endif /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
 #    define nghttp3_ntohl64(N) nghttp3_bswap64(N)
 #    define nghttp3_htonl64(N) nghttp3_bswap64(N)


### PR DESCRIPTION
Summary:
Fix compile error for Android/Linux - undefined symbol: nghttp3_ntohl

Summary:
Found the following compile error when we build the latest nghttp3 for Android/Linux.

```
ld.lld: error: undefined symbol: nghttp3_ntohl >>> referenced by nghttp3_conv.c:58 (third-party/nghttp3/lib/nghttp3_conv.c:58) >>> ../nghttp3#compile-pic-nghttp3_conv.c.o2a37e81d,platform010-clang/lib/nghttp3_conv.c.o:(nghttp3_get_varint)
```

nghttp3_ntohl is not a function or macro. We should use ntohl instead which is also part of previos logic in #135.

Test Plan:
Compile and check no error.

Reviewers:

Subscribers:

Tasks:

Tags: