### PR TITLE
Do not inline nghttp3_objalloc_*_get

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -39,6 +39,8 @@
    dynamic table capacity that QPACK encoder is willing to use. */
 #define NGHTTP3_QPACK_ENCODER_MAX_DTABLE_CAPACITY 4096
 
+nghttp3_objalloc_def(chunk, nghttp3_chunk, oplent);
+
 /*
  * conn_remote_stream_uni returns nonzero if |stream_id| is remote
  * unidirectional stream ID.

--- a/lib/nghttp3_conn.h
+++ b/lib/nghttp3_conn.h
@@ -76,7 +76,7 @@ typedef struct nghttp3_chunk {
   nghttp3_opl_entry oplent;
 } nghttp3_chunk;
 
-nghttp3_objalloc_def(chunk, nghttp3_chunk, oplent);
+nghttp3_objalloc_decl(chunk, nghttp3_chunk, oplent);
 
 struct nghttp3_conn {
   nghttp3_objalloc out_chunk_objalloc;

--- a/lib/nghttp3_ksl.c
+++ b/lib/nghttp3_ksl.c
@@ -36,6 +36,8 @@
 
 static nghttp3_ksl_blk null_blk = {{{NULL, NULL, 0, 0, {0}}}};
 
+nghttp3_objalloc_def(ksl_blk, nghttp3_ksl_blk, oplent);
+
 static size_t ksl_nodelen(size_t keylen) {
   return (sizeof(nghttp3_ksl_node) + keylen - sizeof(uint64_t) + 0xfu) &
          ~(uintptr_t)0xfu;

--- a/lib/nghttp3_ksl.h
+++ b/lib/nghttp3_ksl.h
@@ -108,7 +108,7 @@ struct nghttp3_ksl_blk {
   };
 };
 
-nghttp3_objalloc_def(ksl_blk, nghttp3_ksl_blk, oplent);
+nghttp3_objalloc_decl(ksl_blk, nghttp3_ksl_blk, oplent);
 
 /*
  * nghttp3_ksl_compar is a function type which returns nonzero if key

--- a/lib/nghttp3_objalloc.h
+++ b/lib/nghttp3_objalloc.h
@@ -66,15 +66,25 @@ void nghttp3_objalloc_free(nghttp3_objalloc *objalloc);
 void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
 
 #ifndef NOMEMPOOL
-#  define nghttp3_objalloc_def(NAME, TYPE, OPLENTFIELD)                        \
+#  define nghttp3_objalloc_decl(NAME, TYPE, OPLENTFIELD)                       \
     inline static void nghttp3_objalloc_##NAME##_init(                         \
         nghttp3_objalloc *objalloc, size_t nmemb, const nghttp3_mem *mem) {    \
       nghttp3_objalloc_init(                                                   \
           objalloc, ((sizeof(TYPE) + 0xfu) & ~(uintptr_t)0xfu) * nmemb, mem);  \
     }                                                                          \
                                                                                \
-    inline static TYPE *nghttp3_objalloc_##NAME##_get(                         \
-        nghttp3_objalloc *objalloc) {                                          \
+    TYPE *nghttp3_objalloc_##NAME##_get(nghttp3_objalloc *objalloc);           \
+                                                                               \
+    TYPE *nghttp3_objalloc_##NAME##_len_get(nghttp3_objalloc *objalloc,        \
+                                            size_t len);                       \
+                                                                               \
+    inline static void nghttp3_objalloc_##NAME##_release(                      \
+        nghttp3_objalloc *objalloc, TYPE *obj) {                               \
+      nghttp3_opl_push(&objalloc->opl, &obj->OPLENTFIELD);                     \
+    }
+
+#  define nghttp3_objalloc_def(NAME, TYPE, OPLENTFIELD)                        \
+    TYPE *nghttp3_objalloc_##NAME##_get(nghttp3_objalloc *objalloc) {          \
       nghttp3_opl_entry *oplent = nghttp3_opl_pop(&objalloc->opl);             \
       TYPE *obj;                                                               \
       int rv;                                                                  \
@@ -92,8 +102,8 @@ void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
       return nghttp3_struct_of(oplent, TYPE, OPLENTFIELD);                     \
     }                                                                          \
                                                                                \
-    inline static TYPE *nghttp3_objalloc_##NAME##_len_get(                     \
-        nghttp3_objalloc *objalloc, size_t len) {                              \
+    TYPE *nghttp3_objalloc_##NAME##_len_get(nghttp3_objalloc *objalloc,        \
+                                            size_t len) {                      \
       nghttp3_opl_entry *oplent = nghttp3_opl_pop(&objalloc->opl);             \
       TYPE *obj;                                                               \
       int rv;                                                                  \
@@ -108,14 +118,9 @@ void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
       }                                                                        \
                                                                                \
       return nghttp3_struct_of(oplent, TYPE, OPLENTFIELD);                     \
-    }                                                                          \
-                                                                               \
-    inline static void nghttp3_objalloc_##NAME##_release(                      \
-        nghttp3_objalloc *objalloc, TYPE *obj) {                               \
-      nghttp3_opl_push(&objalloc->opl, &obj->OPLENTFIELD);                     \
     }
 #else /* NOMEMPOOL */
-#  define nghttp3_objalloc_def(NAME, TYPE, OPLENTFIELD)                        \
+#  define nghttp3_objalloc_decl(NAME, TYPE, OPLENTFIELD)                       \
     inline static void nghttp3_objalloc_##NAME##_init(                         \
         nghttp3_objalloc *objalloc, size_t nmemb, const nghttp3_mem *mem) {    \
       nghttp3_objalloc_init(                                                   \
@@ -136,6 +141,8 @@ void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
         nghttp3_objalloc *objalloc, TYPE *obj) {                               \
       nghttp3_mem_free(objalloc->balloc.mem, obj);                             \
     }
+
+#  define nghttp3_objalloc_def(NAME, TYPE, OPLENTFIELD)
 #endif /* NOMEMPOOL */
 
 #endif /* NGHTTP3_OBJALLOC_H */

--- a/lib/nghttp3_stream.c
+++ b/lib/nghttp3_stream.c
@@ -44,6 +44,8 @@
 /* NGHTTP3_MIN_RBLEN is the minimum length of nghttp3_ringbuf */
 #define NGHTTP3_MIN_RBLEN 4
 
+nghttp3_objalloc_def(stream, nghttp3_stream, oplent);
+
 int nghttp3_stream_new(nghttp3_stream **pstream, int64_t stream_id,
                        const nghttp3_stream_callbacks *callbacks,
                        nghttp3_objalloc *out_chunk_objalloc,

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -256,7 +256,7 @@ struct nghttp3_stream {
   };
 };
 
-nghttp3_objalloc_def(stream, nghttp3_stream, oplent);
+nghttp3_objalloc_decl(stream, nghttp3_stream, oplent);
 
 typedef struct nghttp3_frame_entry {
   nghttp3_frame fr;


### PR DESCRIPTION
Do not inline nghttp3_objalloc_*_get because it fails on some platforms.