### PR TITLE
cmake: add BUILD_TESTING, fix MSVC with static + shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 include(GNUInstallDirs)
+include(CMakeDependentOption)
 
 include(CMakeOptions.txt)
 
@@ -176,6 +177,10 @@ foreach(name
   configure_file("${name}.in" "${name}" @ONLY)
 endforeach()
 
+if(ENABLE_SHARED_LIB AND ENABLE_STATIC_LIB AND MSVC AND NOT STATIC_LIB_SUFFIX)
+  set(STATIC_LIB_SUFFIX "_static")
+endif()
+
 include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}" # for config.h
 )
@@ -185,7 +190,9 @@ set(PKGDATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")
 install(FILES README.rst DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
 add_subdirectory(lib)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 add_subdirectory(examples)
 
 

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -7,5 +7,6 @@ option(ENABLE_LIB_ONLY   "Build libnghttp3 only" OFF)
 option(ENABLE_STATIC_LIB "Build libnghttp3 as a static library" ON)
 option(ENABLE_SHARED_LIB "Build libnghttp3 as a shared library" ON)
 option(ENABLE_STATIC_CRT "Build libnghttp3 against the MS LIBCMT[d]")
+cmake_dependent_option(BUILD_TESTING "Enable tests" ON "ENABLE_STATIC_LIB" OFF)
 
 # vim: ft=cmake:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,15 +78,16 @@ if(ENABLE_SHARED_LIB)
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
-# Static library (for unittests because of symbol visibility)
-add_library(nghttp3_static STATIC ${nghttp3_SOURCES})
-set_target_properties(nghttp3_static PROPERTIES
-  COMPILE_FLAGS "${WARNCFLAGS}"
-  VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-  ARCHIVE_OUTPUT_NAME nghttp3${STATIC_LIB_SUFFIX}
-  )
-target_compile_definitions(nghttp3_static PUBLIC "-DNGHTTP3_STATICLIB")
 if(ENABLE_STATIC_LIB)
+  # Public static library
+  add_library(nghttp3_static STATIC ${nghttp3_SOURCES})
+  set_target_properties(nghttp3_static PROPERTIES
+    COMPILE_FLAGS "${WARNCFLAGS}"
+    VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+    ARCHIVE_OUTPUT_NAME nghttp3${STATIC_LIB_SUFFIX}
+    )
+  target_compile_definitions(nghttp3_static PUBLIC "-DNGHTTP3_STATICLIB")
+
   install(TARGETS nghttp3_static
     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()


### PR DESCRIPTION
Add a new option `BUILD_TESTING` to control whether or not the library is built with testing. Also fix a library naming conflict when building both static and shared libraries in MSVC by setting a default of `_static` for `STATIC_LIB_SUFFIX`.