### PR TITLE
cmake: Update ENABLE_STATIC_CRT for cmake >= 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,12 +134,7 @@ else()
 endif()
 
 if(ENABLE_STATIC_CRT)
-  foreach(lang C CXX)
-    foreach(suffix "" _DEBUG _MINSIZEREL _RELEASE _RELWITHDEBINFO)
-      set(var "CMAKE_${lang}_FLAGS${suffix}")
-      string(REPLACE "/MD" "/MT" ${var} "${${var}}")
-    endforeach()
-  endforeach()
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 if(ENABLE_DEBUG)


### PR DESCRIPTION
CMake >= 3.15 doesn't add runtime library selection to compiler flags because of CMP0091 behavior change. There's a new variable for that. Since we require version >= 3.20 there's no need to keep the old behavior.