### PR TITLE
Fix format in nghttp3_macro.h

### DIFF
--- a/lib/nghttp3_macro.h
+++ b/lib/nghttp3_macro.h
@@ -35,7 +35,7 @@
 #include <nghttp3/nghttp3.h>
 
 #define nghttp3_struct_of(ptr, type, member)                                   \
-  ((type *)(void *)((char *)(ptr)-offsetof(type, member)))
+  ((type *)(void *)((char *)(ptr) - offsetof(type, member)))
 
 #define nghttp3_arraylen(A) (sizeof(A) / sizeof(*(A)))
 


### PR DESCRIPTION
Running `make clang-format` updates nghttp3_macro.h format. 
This PR updates the repo with the format changes. 