### PR TITLE
nghttp3_idtr: Remove server field

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -273,7 +273,7 @@ static int conn_new(nghttp3_conn **pconn, int server, int callbacks_version,
     nghttp3_pq_init(&conn->sched[i].spq, cycle_less, mem);
   }
 
-  nghttp3_idtr_init(&conn->remote.bidi.idtr, !server, mem);
+  nghttp3_idtr_init(&conn->remote.bidi.idtr, mem);
 
   conn->callbacks = *callbacks;
   conn->local.settings = *settings;

--- a/lib/nghttp3_idtr.c
+++ b/lib/nghttp3_idtr.c
@@ -27,10 +27,8 @@
 
 #include <assert.h>
 
-void nghttp3_idtr_init(nghttp3_idtr *idtr, int server, const nghttp3_mem *mem) {
+void nghttp3_idtr_init(nghttp3_idtr *idtr, const nghttp3_mem *mem) {
   nghttp3_gaptr_init(&idtr->gap, mem);
-
-  idtr->server = server;
 }
 
 void nghttp3_idtr_free(nghttp3_idtr *idtr) {
@@ -51,9 +49,6 @@ static uint64_t id_from_stream_id(int64_t stream_id) {
 int nghttp3_idtr_open(nghttp3_idtr *idtr, int64_t stream_id) {
   uint64_t q;
 
-  assert((idtr->server && (stream_id & 1)) ||
-         (!idtr->server && !(stream_id & 1)));
-
   q = id_from_stream_id(stream_id);
 
   if (nghttp3_gaptr_is_pushed(&idtr->gap, q, 1)) {
@@ -65,9 +60,6 @@ int nghttp3_idtr_open(nghttp3_idtr *idtr, int64_t stream_id) {
 
 int nghttp3_idtr_is_open(nghttp3_idtr *idtr, int64_t stream_id) {
   uint64_t q;
-
-  assert((idtr->server && (stream_id & 1)) ||
-         (!idtr->server && !(stream_id & 1)));
 
   q = id_from_stream_id(stream_id);
 

--- a/lib/nghttp3_idtr.h
+++ b/lib/nghttp3_idtr.h
@@ -44,18 +44,12 @@ typedef struct nghttp3_idtr {
      stream ID are in the different number spaces.  See
      id_from_stream_id to convert a stream ID to an internal ID. */
   nghttp3_gaptr gap;
-  /* server is nonzero if this object records server initiated stream
-     ID. */
-  int server;
 } nghttp3_idtr;
 
 /*
  * nghttp3_idtr_init initializes |idtr|.
- *
- * If this object records server initiated stream ID (odd number), set
- * |server| to nonzero.
  */
-void nghttp3_idtr_init(nghttp3_idtr *idtr, int server, const nghttp3_mem *mem);
+void nghttp3_idtr_init(nghttp3_idtr *idtr, const nghttp3_mem *mem);
 
 /*
  * nghttp3_idtr_free frees resources allocated for |idtr|.


### PR DESCRIPTION
Remove server field because it is only used in assertion.