### PR TITLE
Consistent macro comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,13 @@ endif()
 # Checks for symbols.
 include(CheckSymbolExists)
 if(HAVE_ENDIAN_H)
-  check_symbol_exists(be64toh "endian.h" HAVE_BE64TOH)
+  check_symbol_exists(be64toh "endian.h" HAVE_DECL_BE64TOH)
 endif()
-if(HAVE_SYS_ENDIAN_H)
-  check_symbol_exists(be64toh "sys/endian.h" HAVE_BE64TOH)
+if(NOT HAVE_DECL_BE64TOH AND HAVE_SYS_ENDIAN_H)
+  check_symbol_exists(be64toh "sys/endian.h" HAVE_DECL_BE64TOH)
 endif()
 
-check_symbol_exists(bswap_64 "byteswap.h" HAVE_BSWAP_64)
+check_symbol_exists(bswap_64 "byteswap.h" HAVE_DECL_BSWAP_64)
 
 if(${CMAKE_C_BYTE_ORDER} STREQUAL "BIG_ENDIAN")
   set(WORDS_BIGENDIAN 1)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -20,8 +20,11 @@
 /* Define to 1 if you have the <byteswap.h> header file. */
 #cmakedefine HAVE_BYTESWAP_H 1
 
-/* Define to 1 if you have the `be64toh' function. */
-#cmakedefine HAVE_BE64TOH 1
+/* Define to 1 if you have the `be64toh' function, otherwise 0. */
+#cmakedefine01 HAVE_DECL_BE64TOH
+
+/* Define to 1 if you have the `bswap_64' function, otherwise 0. */
+#cmakedefine01 HAVE_DECL_BSWAP_64
 
 /* Define WORDS_BIGENDIAN to 1 if target architecture is big
    endian. */

--- a/examples/qpack.h
+++ b/examples/qpack.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif // defined(HAVE_CONFIG_H)
 
 #include <nghttp3/nghttp3.h>
 
@@ -41,4 +41,4 @@ struct Config {
 
 } // namespace nghttp3
 
-#endif // QPACK_H
+#endif // !defined(QPACK_H)

--- a/examples/qpack_decode.h
+++ b/examples/qpack_decode.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif // defined(HAVE_CONFIG_H)
 
 #include <nghttp3/nghttp3.h>
 
@@ -90,4 +90,4 @@ int decode(const std::string_view &outfile, const std::string_view &infile);
 
 } // namespace nghttp3
 
-#endif // QPACK_ENCODE_H
+#endif // !defined(QPACK_DECODE_H)

--- a/examples/qpack_encode.h
+++ b/examples/qpack_encode.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif // defined(HAVE_CONFIG_H)
 
 #include <nghttp3/nghttp3.h>
 
@@ -56,4 +56,4 @@ int encode(const std::string_view &outfile, const std::string_view &infile);
 
 } // namespace nghttp3
 
-#endif // QPACK_ENCODE_H
+#endif // !defined(QPACK_ENCODE_H)

--- a/examples/template.h
+++ b/examples/template.h
@@ -73,4 +73,4 @@ constexpr unsigned long long operator"" _g(unsigned long long g) {
 
 } // namespace nghttp3
 
-#endif // TEMPLATE_H
+#endif // !defined(TEMPLATE_H)

--- a/examples/util.h
+++ b/examples/util.h
@@ -27,37 +27,42 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif // defined(HAVE_CONFIG_H)
 
 #include <stdint.h>
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif /* HAVE_ARPA_INET_H */
+#endif // defined(HAVE_ARPA_INET_H)
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif /* HAVE_NETINET_IN_H */
+#endif // defined(HAVE_NETINET_IN_H)
 
 #ifdef HAVE_ENDIAN_H
 #  include <endian.h>
-#endif /* HAVE_ENDIAN_H */
+#endif // defined(HAVE_ENDIAN_H)x
 
 #ifdef HAVE_SYS_ENDIAN_H
 #  include <sys/endian.h>
-#endif /* HAVE_SYS_ENDIAN_H */
+#endif // defined(HAVE_SYS_ENDIAN_H)
 
 namespace nghttp3 {
 
-#if defined HAVE_BE64TOH || HAVE_DECL_BE64TOH
+#if HAVE_DECL_BE64TOH
 #  define nghttp3_ntohl64(N) be64toh(N)
 #  define nghttp3_htonl64(N) htobe64(N)
-#else /* !HAVE_BE64TOH */
-#  define nghttp3_bswap64(N)                                                   \
-    ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
-#  define nghttp3_ntohl64(N) nghttp3_bswap64(N)
-#  define nghttp3_htonl64(N) nghttp3_bswap64(N)
-#endif /* !HAVE_BE64TOH */
+#else // !HAVE_DECL_BE64TOH
+#  ifdef WORDS_BIGENDIAN
+#    define nghttp3_ntohl64(N) (N)
+#    define nghttp3_htonl64(N) (N)
+#  else // !defined(WORDS_BIGENDIAN)
+#    define nghttp3_bswap64(N)                                                 \
+      ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
+#    define nghttp3_ntohl64(N) nghttp3_bswap64(N)
+#    define nghttp3_htonl64(N) nghttp3_bswap64(N)
+#  endif // !defined(WORDS_BIGENDIAN)
+#endif   // !HAVE_DECL_BE64TOH
 
 } // namespace nghttp3
 

--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -31,11 +31,11 @@
    libcurl) */
 #if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
 #  define WIN32
-#endif
+#endif /* (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32) */
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* defined(__cplusplus) */
 
 #include <stdlib.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
@@ -43,9 +43,9 @@ extern "C" {
    compliant.  See compiler macros and version number in
    https://sourceforge.net/p/predef/wiki/Compilers/ */
 #  include <stdint.h>
-#else /* !defined(_MSC_VER) || (_MSC_VER >= 1800) */
+#else /* !(defined(_MSC_VER) && (_MSC_VER < 1800)) */
 #  include <inttypes.h>
-#endif /* !defined(_MSC_VER) || (_MSC_VER >= 1800) */
+#endif /* !(defined(_MSC_VER) && (_MSC_VER < 1800)) */
 #include <sys/types.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -57,22 +57,22 @@ extern "C" {
 #elif defined(WIN32)
 #  ifdef BUILDING_NGHTTP3
 #    define NGHTTP3_EXTERN __declspec(dllexport)
-#  else /* !BUILDING_NGHTTP3 */
+#  else /* !defined(BUILDING_NGHTTP3) */
 #    define NGHTTP3_EXTERN __declspec(dllimport)
-#  endif /* !BUILDING_NGHTTP3 */
-#else    /* !defined(WIN32) */
+#  endif /* !defined(BUILDING_NGHTTP3) */
+#else    /* !(defined(NGHTTP3_STATICLIB) || defined(WIN32)) */
 #  ifdef BUILDING_NGHTTP3
 #    define NGHTTP3_EXTERN __attribute__((visibility("default")))
-#  else /* !BUILDING_NGHTTP3 */
+#  else /* !defined(BUILDING_NGHTTP3) */
 #    define NGHTTP3_EXTERN
-#  endif /* !BUILDING_NGHTTP3 */
-#endif   /* !defined(WIN32) */
+#  endif /* !defined(BUILDING_NGHTTP3) */
+#endif   /* !(defined(NGHTTP3_STATICLIB) || defined(WIN32)) */
 
 #ifdef _MSC_VER
 #  define NGHTTP3_ALIGN(N) __declspec(align(N))
-#else /* !_MSC_VER */
+#else /* !defined(_MSC_VER) */
 #  define NGHTTP3_ALIGN(N) __attribute__((aligned(N)))
-#endif /* !_MSC_VER */
+#endif /* !defined(_MSC_VER) */
 
 /**
  * @typedef
@@ -2936,6 +2936,6 @@ NGHTTP3_EXTERN int nghttp3_err_is_fatal(int liberr);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* defined(__cplusplus) */
 
-#endif /* NGHTTP3_H */
+#endif /* !defined(NGHTTP3_H) */

--- a/lib/includes/nghttp3/version.h.in
+++ b/lib/includes/nghttp3/version.h.in
@@ -43,4 +43,4 @@
  */
 #define NGHTTP3_VERSION_NUM @PACKAGE_VERSION_NUM@
 
-#endif /* NGHTTP3_VERSION_H */
+#endif /* !defined(NGHTTP3_VERSION_H) */

--- a/lib/nghttp3_balloc.h
+++ b/lib/nghttp3_balloc.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -92,4 +92,4 @@ int nghttp3_balloc_get(nghttp3_balloc *balloc, void **pbuf, size_t n);
  */
 void nghttp3_balloc_clear(nghttp3_balloc *balloc);
 
-#endif /* NGHTTP3_BALLOC_H */
+#endif /* !defined(NGHTTP3_BALLOC_H) */

--- a/lib/nghttp3_buf.h
+++ b/lib/nghttp3_buf.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -71,4 +71,4 @@ void nghttp3_typed_buf_init(nghttp3_typed_buf *tbuf, const nghttp3_buf *buf,
 
 void nghttp3_typed_buf_free(nghttp3_typed_buf *tbuf);
 
-#endif /* NGHTTP3_BUF_H */
+#endif /* !defined(NGHTTP3_BUF_H) */

--- a/lib/nghttp3_conn.h
+++ b/lib/nghttp3_conn.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -204,4 +204,4 @@ int nghttp3_conn_reject_stream(nghttp3_conn *conn, nghttp3_stream *stream);
  */
 nghttp3_stream *nghttp3_conn_get_next_tx_stream(nghttp3_conn *conn);
 
-#endif /* NGHTTP3_CONN_H */
+#endif /* !defined(NGHTTP3_CONN_H) */

--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -28,69 +28,67 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif /* HAVE_ARPA_INET_H */
+#endif /* defined(HAVE_ARPA_INET_H) */
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif /* HAVE_NETINET_IN_H */
+#endif /* defined(HAVE_NETINET_IN_H) */
 
 #ifdef HAVE_BYTESWAP_H
 #  include <byteswap.h>
-#endif /* HAVE_BYTESWAP_H */
+#endif /* defined(HAVE_BYTESWAP_H) */
 
 #ifdef HAVE_ENDIAN_H
 #  include <endian.h>
-#endif /* HAVE_ENDIAN_H */
+#endif /* defined(HAVE_ENDIAN_H) */
 
 #ifdef HAVE_SYS_ENDIAN_H
 #  include <sys/endian.h>
-#endif /* HAVE_SYS_ENDIAN_H */
+#endif /* defined(HAVE_SYS_ENDIAN_H) */
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 #  include <libkern/OSByteOrder.h>
-#endif // __APPLE__
+#endif /* defined(__APPLE__) */
 
 #include <nghttp3/nghttp3.h>
 
-#if defined(HAVE_BE64TOH) ||                                                   \
-  (defined(HAVE_DECL_BE64TOH) && HAVE_DECL_BE64TOH > 0)
+#if HAVE_DECL_BE64TOH
 #  define nghttp3_ntohl64(N) be64toh(N)
 #  define nghttp3_htonl64(N) htobe64(N)
-#else /* !HAVE_BE64TOH */
-#  if defined(WORDS_BIGENDIAN)
+#else /* !HAVE_DECL_BE64TOH */
+#  ifdef WORDS_BIGENDIAN
 #    define nghttp3_ntohl64(N) (N)
 #    define nghttp3_htonl64(N) (N)
-#  else /* !WORDS_BIGENDIAN */
-#    if defined(HAVE_BSWAP_64) ||                                              \
-      (defined(HAVE_DECL_BSWAP_64) && HAVE_DECL_BSWAP_64 > 0)
+#  else /* !defined(WORDS_BIGENDIAN) */
+#    if HAVE_DECL_BSWAP_64
 #      define nghttp3_bswap64 bswap_64
 #    elif defined(WIN32)
 #      define nghttp3_bswap64 _byteswap_uint64
 #    elif defined(__APPLE__)
 #      define nghttp3_bswap64 OSSwapInt64
-#    else /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
+#    else /* !(HAVE_DECL_BSWAP_64 || defined(WIN32) || defined(__APPLE__)) */
 #      define nghttp3_bswap64(N)                                               \
         ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
-#    endif /* !HAVE_BSWAP_64 && !WIN32 && !__APPLE__ */
+#    endif /* !(HAVE_DECL_BSWAP_64 || defined(WIN32) || defined(__APPLE__)) */
 #    define nghttp3_ntohl64(N) nghttp3_bswap64(N)
 #    define nghttp3_htonl64(N) nghttp3_bswap64(N)
-#  endif /* !WORDS_BIGENDIAN */
-#endif   /* !HAVE_BE64TOH */
+#  endif /* !defined(WORDS_BIGENDIAN) */
+#endif   /* !HAVE_DECL_BE64TOH */
 
-#if defined(WIN32)
+#ifdef WIN32
 /* Windows requires ws2_32 library for ntonl family of functions.  We
    define inline functions for those functions so that we don't have
    dependency on that lib. */
 
 #  ifdef _MSC_VER
 #    define STIN static __inline
-#  else
+#  else /* !defined(_MSC_VER) */
 #    define STIN static inline
-#  endif
+#  endif /* !defined(_MSC_VER) */
 
 STIN uint32_t htonl(uint32_t hostlong) {
   uint32_t res;
@@ -128,7 +126,7 @@ STIN uint16_t ntohs(uint16_t netshort) {
   return res;
 }
 
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
 /*
  * nghttp3_get_varint reads variable-length unsigned integer from |p|,
@@ -193,4 +191,4 @@ uint64_t nghttp3_ord_stream_id(int64_t stream_id);
  */
 #define NGHTTP3_PRI_INC_MASK (1 << 7)
 
-#endif /* NGHTTP3_CONV_H */
+#endif /* !defined(NGHTTP3_CONV_H) */

--- a/lib/nghttp3_debug.c
+++ b/lib/nghttp3_debug.c
@@ -51,11 +51,11 @@ void nghttp3_set_debug_vprintf_callback(
   static_debug_vprintf_callback = debug_vprintf_callback;
 }
 
-#else /* !DEBUGBUILD */
+#else /* !defined(DEBUGBUILD) */
 
 void nghttp3_set_debug_vprintf_callback(
   nghttp3_debug_vprintf_callback debug_vprintf_callback) {
   (void)debug_vprintf_callback;
 }
 
-#endif /* !DEBUGBUILD */
+#endif /* !defined(DEBUGBUILD) */

--- a/lib/nghttp3_debug.h
+++ b/lib/nghttp3_debug.h
@@ -28,17 +28,17 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
 #ifdef DEBUGBUILD
 #  define DEBUGF(...) nghttp3_debug_vprintf(__VA_ARGS__)
 void nghttp3_debug_vprintf(const char *format, ...);
-#else
+#else /* !defined(DEBUGBUILD) */
 #  define DEBUGF(...)                                                          \
     do {                                                                       \
     } while (0)
-#endif
+#endif /* !defined(DEBUGBUILD) */
 
-#endif /* NGHTTP3_DEBUG_H */
+#endif /* !defined(NGHTTP3_DEBUG_H) */

--- a/lib/nghttp3_err.h
+++ b/lib/nghttp3_err.h
@@ -27,8 +27,8 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
-#endif /* NGHTTP3_ERR_H */
+#endif /* !defined(NGHTTP3_ERR_H) */

--- a/lib/nghttp3_frame.h
+++ b/lib/nghttp3_frame.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -227,4 +227,4 @@ void nghttp3_frame_headers_free(nghttp3_frame_headers *fr,
 void nghttp3_frame_priority_update_free(nghttp3_frame_priority_update *fr,
                                         const nghttp3_mem *mem);
 
-#endif /* NGHTTP3_FRAME_H */
+#endif /* !defined(NGHTTP3_FRAME_H) */

--- a/lib/nghttp3_gaptr.h
+++ b/lib/nghttp3_gaptr.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -96,4 +96,4 @@ int nghttp3_gaptr_is_pushed(nghttp3_gaptr *gaptr, uint64_t offset,
  */
 void nghttp3_gaptr_drop_first_gap(nghttp3_gaptr *gaptr);
 
-#endif /* NGHTTP3_GAPTR_H */
+#endif /* !defined(NGHTTP3_GAPTR_H) */

--- a/lib/nghttp3_http.h
+++ b/lib/nghttp3_http.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -170,4 +170,4 @@ int nghttp3_http_parse_priority(nghttp3_pri *dest, const uint8_t *value,
 
 int nghttp3_pri_eq(const nghttp3_pri *a, const nghttp3_pri *b);
 
-#endif /* NGHTTP3_HTTP_H */
+#endif /* !defined(NGHTTP3_HTTP_H) */

--- a/lib/nghttp3_idtr.h
+++ b/lib/nghttp3_idtr.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -74,4 +74,4 @@ int nghttp3_idtr_open(nghttp3_idtr *idtr, int64_t stream_id);
  */
 int nghttp3_idtr_is_open(nghttp3_idtr *idtr, int64_t stream_id);
 
-#endif /* NGHTTP3_IDTR_H */
+#endif /* !defined(NGHTTP3_IDTR_H) */

--- a/lib/nghttp3_ksl.c
+++ b/lib/nghttp3_ksl.c
@@ -114,7 +114,7 @@ static void ksl_free_blk(nghttp3_ksl *ksl, nghttp3_ksl_blk *blk) {
 
   ksl_blk_objalloc_del(ksl, blk);
 }
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
 void nghttp3_ksl_free(nghttp3_ksl *ksl) {
   if (!ksl || !ksl->head) {
@@ -123,7 +123,7 @@ void nghttp3_ksl_free(nghttp3_ksl *ksl) {
 
 #ifdef NOMEMPOOL
   ksl_free_blk(ksl, ksl->head);
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   nghttp3_objalloc_free(&ksl->blkalloc);
 }
@@ -732,7 +732,7 @@ void nghttp3_ksl_clear(nghttp3_ksl *ksl) {
 
 #ifdef NOMEMPOOL
   ksl_free_blk(ksl, ksl->head);
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
   ksl->front = ksl->back = ksl->head = NULL;
   ksl->n = 0;
@@ -771,7 +771,7 @@ void nghttp3_ksl_print(const nghttp3_ksl *ksl) {
 
   ksl_print(ksl, ksl->head, 0);
 }
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 nghttp3_ksl_it nghttp3_ksl_begin(const nghttp3_ksl *ksl) {
   nghttp3_ksl_it it;

--- a/lib/nghttp3_ksl.h
+++ b/lib/nghttp3_ksl.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <stdlib.h>
 
@@ -273,7 +273,7 @@ void nghttp3_ksl_clear(nghttp3_ksl *ksl);
  * the debugging purpose only.
  */
 void nghttp3_ksl_print(const nghttp3_ksl *ksl);
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 /*
  * nghttp3_ksl_it_init initializes |it|.
@@ -348,4 +348,4 @@ int nghttp3_ksl_range_compar(const nghttp3_ksl_key *lhs,
 int nghttp3_ksl_range_exclusive_compar(const nghttp3_ksl_key *lhs,
                                        const nghttp3_ksl_key *rhs);
 
-#endif /* NGHTTP3_KSL_H */
+#endif /* !defined(NGHTTP3_KSL_H) */

--- a/lib/nghttp3_macro.h
+++ b/lib/nghttp3_macro.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <stddef.h>
 
@@ -71,4 +71,4 @@ nghttp3_min_def(uint32, uint32_t);
 nghttp3_min_def(uint64, uint64_t);
 nghttp3_min_def(size, size_t);
 
-#endif /* NGHTTP3_MACRO_H */
+#endif /* !defined(NGHTTP3_MACRO_H) */

--- a/lib/nghttp3_map.c
+++ b/lib/nghttp3_map.c
@@ -115,7 +115,7 @@ void nghttp3_map_print_distance(const nghttp3_map *map) {
             hash(bkt->key, map->hashbits), bkt->key, idx, bkt->psl);
   }
 }
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
 static int insert(nghttp3_map_bucket *table, size_t hashbits,
                   nghttp3_map_key_type key, void *data) {

--- a/lib/nghttp3_map.h
+++ b/lib/nghttp3_map.h
@@ -29,7 +29,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -124,6 +124,6 @@ int nghttp3_map_each(const nghttp3_map *map, int (*func)(void *data, void *ptr),
 
 #ifndef WIN32
 void nghttp3_map_print_distance(const nghttp3_map *map);
-#endif /* !WIN32 */
+#endif /* !defined(WIN32) */
 
-#endif /* NGHTTP3_MAP_H */
+#endif /* !defined(NGHTTP3_MAP_H) */

--- a/lib/nghttp3_mem.c
+++ b/lib/nghttp3_mem.c
@@ -73,7 +73,7 @@ void *nghttp3_mem_calloc(const nghttp3_mem *mem, size_t nmemb, size_t size) {
 void *nghttp3_mem_realloc(const nghttp3_mem *mem, void *ptr, size_t size) {
   return mem->realloc(ptr, size, mem->user_data);
 }
-#else  /* MEMDEBUG */
+#else  /* defined(MEMDEBUG) */
 void *nghttp3_mem_malloc_debug(const nghttp3_mem *mem, size_t size,
                                const char *func, const char *file,
                                size_t line) {
@@ -121,4 +121,4 @@ void *nghttp3_mem_realloc_debug(const nghttp3_mem *mem, void *ptr, size_t size,
 
   return nptr;
 }
-#endif /* MEMDEBUG */
+#endif /* defined(MEMDEBUG) */

--- a/lib/nghttp3_mem.h
+++ b/lib/nghttp3_mem.h
@@ -29,7 +29,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -40,7 +40,7 @@ void *nghttp3_mem_malloc(const nghttp3_mem *mem, size_t size);
 void nghttp3_mem_free(const nghttp3_mem *mem, void *ptr);
 void *nghttp3_mem_calloc(const nghttp3_mem *mem, size_t nmemb, size_t size);
 void *nghttp3_mem_realloc(const nghttp3_mem *mem, void *ptr, size_t size);
-#else /* MEMDEBUG */
+#else /* defined(MEMDEBUG) */
 void *nghttp3_mem_malloc_debug(const nghttp3_mem *mem, size_t size,
                                const char *func, const char *file, size_t line);
 
@@ -75,6 +75,6 @@ void *nghttp3_mem_realloc_debug(const nghttp3_mem *mem, void *ptr, size_t size,
 #  define nghttp3_mem_realloc(MEM, PTR, SIZE)                                  \
     nghttp3_mem_realloc_debug((MEM), (PTR), (SIZE), __func__, __FILE__,        \
                               __LINE__)
-#endif /* MEMDEBUG */
+#endif /* defined(MEMDEBUG) */
 
-#endif /* NGHTTP3_MEM_H */
+#endif /* !defined(NGHTTP3_MEM_H) */

--- a/lib/nghttp3_objalloc.h
+++ b/lib/nghttp3_objalloc.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -119,7 +119,7 @@ void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
                                                                                \
       return nghttp3_struct_of(oplent, TYPE, OPLENTFIELD);                     \
     }
-#else /* NOMEMPOOL */
+#else /* defined(NOMEMPOOL) */
 #  define nghttp3_objalloc_decl(NAME, TYPE, OPLENTFIELD)                       \
     inline static void nghttp3_objalloc_##NAME##_init(                         \
       nghttp3_objalloc *objalloc, size_t nmemb, const nghttp3_mem *mem) {      \
@@ -143,6 +143,6 @@ void nghttp3_objalloc_clear(nghttp3_objalloc *objalloc);
     }
 
 #  define nghttp3_objalloc_def(NAME, TYPE, OPLENTFIELD)
-#endif /* NOMEMPOOL */
+#endif /* defined(NOMEMPOOL) */
 
-#endif /* NGHTTP3_OBJALLOC_H */
+#endif /* !defined(NGHTTP3_OBJALLOC_H) */

--- a/lib/nghttp3_opl.h
+++ b/lib/nghttp3_opl.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -63,4 +63,4 @@ nghttp3_opl_entry *nghttp3_opl_pop(nghttp3_opl *opl);
 
 void nghttp3_opl_clear(nghttp3_opl *opl);
 
-#endif /* NGHTTP3_OPL_H */
+#endif /* !defined(NGHTTP3_OPL_H) */

--- a/lib/nghttp3_pq.h
+++ b/lib/nghttp3_pq.h
@@ -29,7 +29,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -134,4 +134,4 @@ void nghttp3_pq_remove(nghttp3_pq *pq, nghttp3_pq_entry *item);
  */
 void nghttp3_pq_clear(nghttp3_pq *pq);
 
-#endif /* NGHTTP3_PQ_H */
+#endif /* !defined(NGHTTP3_PQ_H) */

--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -1122,7 +1122,7 @@ static int reserve_buf(nghttp3_buf *buf, size_t extra_size,
 
 #ifndef WIN32
   n = 1u << (32 - __builtin_clz((uint32_t)n - 1));
-#else  /* WIN32 */
+#else  /* defined(WIN32) */
   /* Round up to the next highest power of 2 from Bit Twiddling
      Hacks */
   --n;
@@ -1132,7 +1132,7 @@ static int reserve_buf(nghttp3_buf *buf, size_t extra_size,
   n |= n >> 8;
   n |= n >> 16;
   ++n;
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
   return nghttp3_buf_reserve(buf, n, mem);
 }

--- a/lib/nghttp3_qpack.h
+++ b/lib/nghttp3_qpack.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -1007,4 +1007,4 @@ void nghttp3_qpack_decoder_emit_literal(nghttp3_qpack_decoder *decoder,
 int nghttp3_qpack_decoder_write_section_ack(
   nghttp3_qpack_decoder *decoder, const nghttp3_qpack_stream_context *sctx);
 
-#endif /* NGHTTP3_QPACK_H */
+#endif /* !defined(NGHTTP3_QPACK_H) */

--- a/lib/nghttp3_qpack_huffman.h
+++ b/lib/nghttp3_qpack_huffman.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -105,4 +105,4 @@ nghttp3_qpack_huffman_decode(nghttp3_qpack_huffman_decode_context *ctx,
 int nghttp3_qpack_huffman_decode_failure_state(
   nghttp3_qpack_huffman_decode_context *ctx);
 
-#endif /* NGHTTP3_QPACK_HUFFMAN_H */
+#endif /* !defined(NGHTTP3_QPACK_HUFFMAN_H) */

--- a/lib/nghttp3_range.h
+++ b/lib/nghttp3_range.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -78,4 +78,4 @@ void nghttp3_range_cut(nghttp3_range *left, nghttp3_range *right,
  */
 int nghttp3_range_not_after(const nghttp3_range *a, const nghttp3_range *b);
 
-#endif /* NGHTTP3_RANGE_H */
+#endif /* !defined(NGHTTP3_RANGE_H) */

--- a/lib/nghttp3_rcbuf.h
+++ b/lib/nghttp3_rcbuf.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -78,4 +78,4 @@ int nghttp3_rcbuf_new2(nghttp3_rcbuf **rcbuf_ptr, const uint8_t *src,
  */
 void nghttp3_rcbuf_del(nghttp3_rcbuf *rcbuf);
 
-#endif /* NGHTTP3_RCBUF_H */
+#endif /* !defined(NGHTTP3_RCBUF_H) */

--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -29,7 +29,7 @@
 #include <string.h>
 #ifdef WIN32
 #  include <intrin.h>
-#endif
+#endif /* defined(WIN32) */
 
 #include "nghttp3_macro.h"
 
@@ -42,16 +42,17 @@ unsigned int __popcnt(unsigned int x) {
   }
   return c;
 }
-#endif
+#endif /* defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) ||      \
+          (defined(_M_ARM64) && _MSC_VER < 1941)) */
 
 int nghttp3_ringbuf_init(nghttp3_ringbuf *rb, size_t nmemb, size_t size,
                          const nghttp3_mem *mem) {
   if (nmemb) {
 #ifdef WIN32
     assert(1 == __popcnt((unsigned int)nmemb));
-#else
+#else  /* !defined(WIN32) */
     assert(1 == __builtin_popcount((unsigned int)nmemb));
-#endif
+#endif /* !defined(WIN32) */
 
     rb->buf = nghttp3_mem_malloc(mem, nmemb * size);
     if (rb->buf == NULL) {
@@ -129,9 +130,9 @@ int nghttp3_ringbuf_reserve(nghttp3_ringbuf *rb, size_t nmemb) {
 
 #ifdef WIN32
   assert(1 == __popcnt((unsigned int)nmemb));
-#else
+#else  /* !defined(WIN32) */
   assert(1 == __builtin_popcount((unsigned int)nmemb));
-#endif
+#endif /* !defined(WIN32) */
 
   buf = nghttp3_mem_malloc(rb->mem, nmemb * rb->size);
   if (buf == NULL) {

--- a/lib/nghttp3_ringbuf.h
+++ b/lib/nghttp3_ringbuf.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -110,4 +110,4 @@ int nghttp3_ringbuf_full(nghttp3_ringbuf *rb);
 
 int nghttp3_ringbuf_reserve(nghttp3_ringbuf *rb, size_t nmemb);
 
-#endif /* NGHTTP3_RINGBUF_H */
+#endif /* !defined(NGHTTP3_RINGBUF_H) */

--- a/lib/nghttp3_str.h
+++ b/lib/nghttp3_str.h
@@ -29,7 +29,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -37,4 +37,4 @@ uint8_t *nghttp3_cpymem(uint8_t *dest, const uint8_t *src, size_t n);
 
 void nghttp3_downcase(uint8_t *s, size_t len);
 
-#endif /* NGHTTP3_STR_H */
+#endif /* !defined(NGHTTP3_STR_H) */

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -394,4 +394,4 @@ int nghttp3_client_stream_uni(int64_t stream_id);
  */
 int nghttp3_server_stream_uni(int64_t stream_id);
 
-#endif /* NGHTTP3_STREAM_H */
+#endif /* !defined(NGHTTP3_STREAM_H) */

--- a/lib/nghttp3_tnode.h
+++ b/lib/nghttp3_tnode.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -63,4 +63,4 @@ int nghttp3_tnode_schedule(nghttp3_tnode *tnode, nghttp3_pq *pq,
  */
 int nghttp3_tnode_is_scheduled(nghttp3_tnode *tnode);
 
-#endif /* NGHTTP3_TNODE_H */
+#endif /* !defined(NGHTTP3_TNODE_H) */

--- a/lib/nghttp3_unreachable.c
+++ b/lib/nghttp3_unreachable.c
@@ -29,11 +29,11 @@
 #include <errno.h>
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
-#endif /* HAVE_UNISTD_H */
+#endif /* defined(HAVE_UNISTD_H) */
 #include <stdlib.h>
 #ifdef WIN32
 #  include <io.h>
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
 void nghttp3_unreachable_fail(const char *file, int line, const char *func) {
   char *buf;
@@ -62,9 +62,9 @@ void nghttp3_unreachable_fail(const char *file, int line, const char *func) {
 #ifndef WIN32
   while (write(STDERR_FILENO, buf, (size_t)rv) == -1 && errno == EINTR)
     ;
-#else  /* WIN32 */
+#else  /* defined(WIN32) */
   _write(_fileno(stderr), buf, (unsigned int)rv);
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
   free(buf);
 

--- a/lib/nghttp3_unreachable.h
+++ b/lib/nghttp3_unreachable.h
@@ -28,26 +28,26 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
 #ifdef __FILE_NAME__
 #  define NGHTTP3_FILE_NAME __FILE_NAME__
-#else /* !__FILE_NAME__ */
+#else /* !defined(__FILE_NAME__) */
 #  define NGHTTP3_FILE_NAME "(file)"
-#endif /* !__FILE_NAME__ */
+#endif /* !defined(__FILE_NAME__) */
 
 #define nghttp3_unreachable()                                                  \
   nghttp3_unreachable_fail(NGHTTP3_FILE_NAME, __LINE__, __func__)
 
 #ifdef _MSC_VER
 __declspec(noreturn)
-#endif /* _MSC_VER */
+#endif /* defined(_MSC_VER) */
     void nghttp3_unreachable_fail(const char *file, int line, const char *func)
 #ifndef _MSC_VER
         __attribute__((noreturn))
-#endif /* !_MSC_VER */
+#endif /* !defined(_MSC_VER) */
         ;
 
-#endif /* NGHTTP3_UNREACHABLE_H */
+#endif /* !defined(NGHTTP3_UNREACHABLE_H) */

--- a/lib/nghttp3_vec.h
+++ b/lib/nghttp3_vec.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 
@@ -38,4 +38,4 @@
  */
 int64_t nghttp3_vec_len_varint(const nghttp3_vec *vec, size_t n);
 
-#endif /* NGHTTP3_VEC_H */
+#endif /* !defined(NGHTTP3_VEC_H) */

--- a/lib/nghttp3_version.c
+++ b/lib/nghttp3_version.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp3/nghttp3.h>
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -26,7 +26,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include "munit.h"
 

--- a/tests/nghttp3_conn_test.h
+++ b/tests/nghttp3_conn_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -63,4 +63,4 @@ munit_void_test_decl(test_nghttp3_conn_stream_data_overflow);
 munit_void_test_decl(test_nghttp3_conn_get_frame_payload_left);
 munit_void_test_decl(test_nghttp3_conn_update_ack_offset);
 
-#endif /* NGHTTP3_CONN_TEST_H */
+#endif /* !defined(NGHTTP3_CONN_TEST_H) */

--- a/tests/nghttp3_conv_test.h
+++ b/tests/nghttp3_conv_test.h
@@ -27,6 +27,6 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
-#endif /* NGHTTP3_CONV_TEST_H */
+#endif /* !defined(NGHTTP3_CONV_TEST_H) */

--- a/tests/nghttp3_http_test.h
+++ b/tests/nghttp3_http_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -38,4 +38,4 @@ extern const MunitSuite http_suite;
 munit_void_test_decl(test_nghttp3_http_parse_priority);
 munit_void_test_decl(test_nghttp3_check_header_value);
 
-#endif /* NGHTTP3_HTTP_TEST_H */
+#endif /* !defined(NGHTTP3_HTTP_TEST_H) */

--- a/tests/nghttp3_qpack_test.h
+++ b/tests/nghttp3_qpack_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -47,4 +47,4 @@ munit_void_test_decl(test_nghttp3_qpack_decoder_reconstruct_ricnt);
 munit_void_test_decl(test_nghttp3_qpack_decoder_read_encoder);
 munit_void_test_decl(test_nghttp3_qpack_encoder_read_decoder);
 
-#endif /* NGHTTP3_QPACK_TEST_H */
+#endif /* !defined(NGHTTP3_QPACK_TEST_H) */

--- a/tests/nghttp3_test_helper.h
+++ b/tests/nghttp3_test_helper.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include "nghttp3_buf.h"
 #include "nghttp3_frame.h"
@@ -69,4 +69,4 @@ void nghttp3_write_frame_qpack_dyn(nghttp3_buf *dest, nghttp3_buf *ebuf,
  */
 void nghttp3_write_frame_data(nghttp3_buf *dest, size_t len);
 
-#endif /* NGHTTP3_TEST_HELPER */
+#endif /* !defined(NGHTTP3_TEST_HELPER) */

--- a/tests/nghttp3_tnode_test.h
+++ b/tests/nghttp3_tnode_test.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #define MUNIT_ENABLE_ASSERT_ALIASES
 
@@ -37,4 +37,4 @@ extern const MunitSuite tnode_suite;
 
 munit_void_test_decl(test_nghttp3_tnode_schedule);
 
-#endif /* NGHTTP3_TNODE_TEST_H */
+#endif /* !defined(NGHTTP3_TNODE_TEST_H) */


### PR DESCRIPTION
Make macro comments consistent throughout the codebase.  Fixup HAVE_BE64TOH and HAVE_BSWAP_64 cmakedefine to match the semantics of autotools.  Fix nghttp3_ntohl64 and nghttp3_htonl64 for bigendian in examples.