### PR TITLE
Explicitly deny new server-initiated bidirectional stream

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -434,6 +434,10 @@ nghttp3_ssize nghttp3_conn_read_stream(nghttp3_conn *conn, int64_t stream_id,
             return rv;
           }
         }
+      } else if(!nghttp3_stream_uni(stream_id)) {
+        /* server does not expect to receive new server initiated
+           bidirectional stream from client. */
+        return NGHTTP3_ERR_H3_STREAM_CREATION_ERROR;
       } else {
         /* unidirectional stream */
         if (srclen == 0 && fin) {


### PR DESCRIPTION
Vanilla HTTP/3 does not allow server to create bidirectional stream. libnghttp3 expects that application configures the QUIC stack like so. Still it would be nice to explicitly deny new server-initiated bidirectional stream for clarity.