### PR TITLE
nghttp3_gaptr: Check iterator

### DIFF
--- a/lib/nghttp3_gaptr.c
+++ b/lib/nghttp3_gaptr.c
@@ -152,6 +152,10 @@ int nghttp3_gaptr_is_pushed(nghttp3_gaptr *gaptr, uint64_t offset,
 
   it = nghttp3_ksl_lower_bound_search(&gaptr->gap, &q,
                                       nghttp3_ksl_range_exclusive_search);
+  if (nghttp3_ksl_it_end(&it)) {
+    return 0;
+  }
+
   m = nghttp3_range_intersect(&q, (nghttp3_range *)nghttp3_ksl_it_key(&it));
 
   return nghttp3_range_len(&m) == 0;


### PR DESCRIPTION
In practice, we never pass the number larger than NGHTTP3_MAX_VARINT, but it should check whether the iterator is beyond the range as an API contract.