### PR TITLE
nghttp3_gaptr: Assert !nghttp3_ksl_it_end

### DIFF
--- a/lib/nghttp3_gaptr.c
+++ b/lib/nghttp3_gaptr.c
@@ -152,6 +152,9 @@ int nghttp3_gaptr_is_pushed(nghttp3_gaptr *gaptr, uint64_t offset,
 
   it = nghttp3_ksl_lower_bound_search(&gaptr->gap, &q,
                                       nghttp3_ksl_range_exclusive_search);
+
+  assert(!nghttp3_ksl_it_end(&it));
+
   m = nghttp3_range_intersect(&q, (nghttp3_range *)nghttp3_ksl_it_key(&it));
 
   return nghttp3_range_len(&m) == 0;


### PR DESCRIPTION
Assert !nghttp3_ksl_it_end in nghttp3_gaptr_is_pushed just like we do in the other functions