### PR TITLE
Remove redundant condition in nghttp3_conn_submit_request()

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2480,8 +2480,6 @@ typedef struct nghttp3_data_reader {
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
- * :macro:`NGHTTP3_ERR_INVALID_ARGUMENT`
- *     |stream_id| identifies unidirectional stream.
  * :macro:`NGHTTP3_ERR_CONN_CLOSING`
  *     Connection is shutting down, and no new stream is allowed.
  * :macro:`NGHTTP3_ERR_STREAM_IN_USE`

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2203,11 +2203,7 @@ int nghttp3_conn_submit_request(nghttp3_conn *conn, int64_t stream_id,
   assert(stream_id <= (int64_t)NGHTTP3_MAX_VARINT);
   assert(nghttp3_client_stream_bidi(stream_id));
 
-  /* TODO Should we check that stream_id is client stream_id? */
   /* TODO Check GOAWAY last stream ID */
-  if (nghttp3_stream_uni(stream_id)) {
-    return NGHTTP3_ERR_INVALID_ARGUMENT;
-  }
 
   if (conn->flags & NGHTTP3_CONN_FLAG_GOAWAY_RECVED) {
     return NGHTTP3_ERR_CONN_CLOSING;


### PR DESCRIPTION
The preceding assertion for nghttp3_client_stream_bidi() ensures that nghttp3_stream_uni() always returns false.