### PR TITLE
Avoid STOP_SENDING for unknown stream type in case fin is set.

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -607,6 +607,9 @@ nghttp3_ssize nghttp3_conn_read_uni(nghttp3_conn *conn, nghttp3_stream *stream,
     break;
   case NGHTTP3_STREAM_TYPE_UNKNOWN:
     nconsumed = (nghttp3_ssize)srclen;
+    if (fin) {
+      break;
+    }
 
     rv = conn_call_stop_sending(conn, stream, NGHTTP3_H3_STREAM_CREATION_ERROR);
     if (rv != 0) {


### PR DESCRIPTION
My HTTP3 client receives a grease frame from [quiche](https://github.com/cloudflare/quiche/blob/master/quiche/src/h3/mod.rs#L2089) and it includes a fin.

```
STREAM id=15 fin=1 off=0 len=26 dir=Unidirectional origin=Server-initiated
    Frame Type: STREAM (0x000000000000000f)
    Stream ID: 15
    Offset: 0
    Length: 26
    Stream Data: f739d7873c274c684752454153452069732074686520776f7264
```

after running gdb I see that nghttp3 does `nghttp3_conn_read_uni` and then identifies `stream->type` is `NGHTTP3_STREAM_TYPE_UNKNOWN` and proceeds with `conn_call_stop_sending`.


Looking at [RFC9114 Reserved Stream Types](https://datatracker.ietf.org/doc/html/rfc9114#stream-grease)
        
> Endpoints MUST NOT consider these streams to have any meaning upon receipt.

If I understand this right, maybe it is never a good idea to send STOP_SENDING?
