### PR TITLE
Add a CMake option to support disabling the popcnt instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,12 @@ foreach(name
   configure_file("${name}.in" "${name}" @ONLY)
 endforeach()
 
+option(ENABLE_POPCNT "Enable popcnt instruction" ON)
+
+if(NOT ENABLE_POPCNT)
+  add_definitions(-DDISABLE_POPCNT)
+endif()
+
 if(ENABLE_SHARED_LIB AND ENABLE_STATIC_LIB AND MSVC AND NOT STATIC_LIB_SUFFIX)
   set(STATIC_LIB_SUFFIX "_static")
 endif()
@@ -213,6 +219,8 @@ message(STATUS "summary of build options:
       CXXFLAGS:       ${CMAKE_CXX_FLAGS_${_build_type}} ${CMAKE_CXX_FLAGS}
       WARNCFLAGS:     ${WARNCFLAGS}
       WARNCXXFLAGS:   ${WARNCXXFLAGS}
+    SIMD instruction:
+      Enable popcnt:  ${ENABLE_POPCNT}
     Library:
       Shared:         ${ENABLE_SHARED_LIB}
       Static:         ${ENABLE_STATIC_LIB}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,8 +179,6 @@ foreach(name
   configure_file("${name}.in" "${name}" @ONLY)
 endforeach()
 
-option(ENABLE_POPCNT "Enable popcnt instruction" ON)
-
 if(NOT ENABLE_POPCNT)
   add_definitions(-DDISABLE_POPCNT)
 endif()

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -7,6 +7,7 @@ option(ENABLE_LIB_ONLY   "Build libnghttp3 only" OFF)
 option(ENABLE_STATIC_LIB "Build libnghttp3 as a static library" ON)
 option(ENABLE_SHARED_LIB "Build libnghttp3 as a shared library" ON)
 option(ENABLE_STATIC_CRT "Build libnghttp3 against the MS LIBCMT[d]")
+option(ENABLE_POPCNT "Enable popcnt instruction" ON)
 cmake_dependent_option(BUILD_TESTING "Enable tests" ON "ENABLE_STATIC_LIB" OFF)
 
 # vim: ft=cmake:

--- a/lib/nghttp3_ringbuf.c
+++ b/lib/nghttp3_ringbuf.c
@@ -35,8 +35,9 @@
 
 #ifndef NDEBUG
 static int ispow2(size_t n) {
-#  if defined(_MSC_VER) && !defined(__clang__) &&                              \
-    (defined(_M_ARM) || (defined(_M_ARM64) && _MSC_VER < 1941))
+#  if defined(DISABLE_POPCNT) ||                                               \
+    (defined(_MSC_VER) && !defined(__clang__) &&                               \
+    (defined(_M_ARM) || (defined(_M_ARM64) && _MSC_VER < 1941)))
   return n && !(n & (n - 1));
 #  elif defined(WIN32)
   return 1 == __popcnt((unsigned int)n);


### PR DESCRIPTION
ENABLE_POPCNT is on by default, so the existing logic will not be affected.