### PR TITLE
Treat malformed HTTP message as a connection error

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -1573,10 +1573,6 @@ nghttp3_ssize nghttp3_conn_read_bidi(nghttp3_conn *conn, size_t *pnproc,
       nread = nghttp3_conn_on_headers(conn, stream, p, len,
                                       (int64_t)len == rstate->left);
       if (nread < 0) {
-        if (nread == NGHTTP3_ERR_MALFORMED_HTTP_HEADER) {
-          goto http_header_error;
-        }
-
         return nread;
       }
 
@@ -1615,10 +1611,6 @@ nghttp3_ssize nghttp3_conn_read_bidi(nghttp3_conn *conn, size_t *pnproc,
       }
 
       if (rv != 0) {
-        if (rv == NGHTTP3_ERR_MALFORMED_HTTP_HEADER) {
-          goto http_header_error;
-        }
-
         return rv;
       }
 
@@ -1656,24 +1648,6 @@ nghttp3_ssize nghttp3_conn_read_bidi(nghttp3_conn *conn, size_t *pnproc,
       assert(0 == rv);
 
       nghttp3_stream_read_state_reset(rstate);
-
-      break;
-
-    http_header_error:
-      stream->flags |= NGHTTP3_STREAM_FLAG_HTTP_ERROR;
-
-      busy = 1;
-      rstate->state = NGHTTP3_REQ_STREAM_STATE_IGN_REST;
-
-      rv = conn_call_stop_sending(conn, stream, NGHTTP3_H3_MESSAGE_ERROR);
-      if (rv != 0) {
-        return rv;
-      }
-
-      rv = conn_call_reset_stream(conn, stream, NGHTTP3_H3_MESSAGE_ERROR);
-      if (rv != 0) {
-        return rv;
-      }
 
       break;
     case NGHTTP3_REQ_STREAM_STATE_IGN_FRAME:

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -131,10 +131,6 @@ typedef struct nghttp3_stream_read_state {
 /* NGHTTP3_STREAM_FLAG_PRIORITY_UPDATE_RECVED indicates that server
    received PRIORITY_UPDATE frame for this stream. */
 #define NGHTTP3_STREAM_FLAG_PRIORITY_UPDATE_RECVED 0x0800u
-/* NGHTTP3_STREAM_FLAG_HTTP_ERROR indicates that
-   NGHTTP3_ERR_MALFORMED_HTTP_HEADER error is encountered while
-   processing incoming HTTP fields. */
-#define NGHTTP3_STREAM_FLAG_HTTP_ERROR 0x1000u
 
 typedef enum nghttp3_stream_http_state {
   NGHTTP3_HTTP_STATE_NONE,


### PR DESCRIPTION
These messages mostly come from broken implementations and already treated as a stream error.  This kind of error means how broken the sender is.  Also this vastly simplifies the error handling, and we get less moving parts which is also nice.