### PR TITLE
Remove length from nghttp3_frame

### DIFF
--- a/lib/nghttp3_frame.c
+++ b/lib/nghttp3_frame.c
@@ -31,21 +31,22 @@
 #include "nghttp3_conv.h"
 #include "nghttp3_str.h"
 
-uint8_t *nghttp3_frame_write_hd(uint8_t *p, const nghttp3_frame_hd *hd) {
-  p = nghttp3_put_varint(p, hd->type);
-  p = nghttp3_put_varint(p, hd->length);
+uint8_t *nghttp3_frame_write_hd(uint8_t *p, int64_t type, int64_t payloadlen) {
+  p = nghttp3_put_varint(p, type);
+  p = nghttp3_put_varint(p, payloadlen);
   return p;
 }
 
-size_t nghttp3_frame_write_hd_len(const nghttp3_frame_hd *hd) {
-  return nghttp3_put_varintlen(hd->type) + nghttp3_put_varintlen(hd->length);
+size_t nghttp3_frame_write_hd_len(int64_t type, int64_t payloadlen) {
+  return nghttp3_put_varintlen(type) + nghttp3_put_varintlen(payloadlen);
 }
 
 uint8_t *nghttp3_frame_write_settings(uint8_t *p,
-                                      const nghttp3_frame_settings *fr) {
+                                      const nghttp3_frame_settings *fr,
+                                      int64_t payloadlen) {
   size_t i;
 
-  p = nghttp3_frame_write_hd(p, &fr->hd);
+  p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
 
   for (i = 0; i < fr->niv; ++i) {
     p = nghttp3_put_varint(p, (int64_t)fr->iv[i].id);
@@ -71,9 +72,9 @@ size_t nghttp3_frame_write_settings_len(int64_t *ppayloadlen,
          nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
-uint8_t *nghttp3_frame_write_goaway(uint8_t *p,
-                                    const nghttp3_frame_goaway *fr) {
-  p = nghttp3_frame_write_hd(p, &fr->hd);
+uint8_t *nghttp3_frame_write_goaway(uint8_t *p, const nghttp3_frame_goaway *fr,
+                                    int64_t payloadlen) {
+  p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
   p = nghttp3_put_varint(p, fr->id);
 
   return p;
@@ -89,10 +90,9 @@ size_t nghttp3_frame_write_goaway_len(int64_t *ppayloadlen,
          nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
-uint8_t *
-nghttp3_frame_write_priority_update(uint8_t *p,
-                                    const nghttp3_frame_priority_update *fr) {
-  p = nghttp3_frame_write_hd(p, &fr->hd);
+uint8_t *nghttp3_frame_write_priority_update(
+  uint8_t *p, const nghttp3_frame_priority_update *fr, int64_t payloadlen) {
+  p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
   p = nghttp3_put_varint(p, fr->pri_elem_id);
   if (fr->datalen) {
     p = nghttp3_cpymem(p, fr->data, fr->datalen);
@@ -107,13 +107,13 @@ size_t nghttp3_frame_write_priority_update_len(
 
   *ppayloadlen = (int64_t)payloadlen;
 
-  return nghttp3_put_varintlen(fr->hd.type) +
+  return nghttp3_put_varintlen(fr->type) +
          nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 
-uint8_t *nghttp3_frame_write_origin(uint8_t *p,
-                                    const nghttp3_frame_origin *fr) {
-  p = nghttp3_frame_write_hd(p, &fr->hd);
+uint8_t *nghttp3_frame_write_origin(uint8_t *p, const nghttp3_frame_origin *fr,
+                                    int64_t payloadlen) {
+  p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
   if (fr->origin_list.len) {
     p = nghttp3_cpymem(p, fr->origin_list.base, fr->origin_list.len);
   }
@@ -127,7 +127,7 @@ size_t nghttp3_frame_write_origin_len(int64_t *ppayloadlen,
 
   *ppayloadlen = (int64_t)payloadlen;
 
-  return nghttp3_put_varintlen(fr->hd.type) +
+  return nghttp3_put_varintlen(fr->type) +
          nghttp3_put_varintlen((int64_t)payloadlen) + payloadlen;
 }
 

--- a/lib/nghttp3_frame.h
+++ b/lib/nghttp3_frame.h
@@ -54,17 +54,12 @@
 #define NGHTTP3_H2_FRAME_WINDOW_UPDATE 0x08
 #define NGHTTP3_H2_FRAME_CONTINUATION 0x9
 
-typedef struct nghttp3_frame_hd {
-  int64_t type;
-  int64_t length;
-} nghttp3_frame_hd;
-
 typedef struct nghttp3_frame_data {
-  nghttp3_frame_hd hd;
+  int64_t type;
 } nghttp3_frame_data;
 
 typedef struct nghttp3_frame_headers {
-  nghttp3_frame_hd hd;
+  int64_t type;
   nghttp3_nv *nva;
   size_t nvlen;
 } nghttp3_frame_headers;
@@ -86,20 +81,20 @@ typedef struct nghttp3_settings_entry {
 } nghttp3_settings_entry;
 
 typedef struct nghttp3_frame_settings {
-  nghttp3_frame_hd hd;
+  int64_t type;
   size_t niv;
   nghttp3_settings_entry iv[1];
 } nghttp3_frame_settings;
 
 typedef struct nghttp3_frame_goaway {
-  nghttp3_frame_hd hd;
+  int64_t type;
   int64_t id;
 } nghttp3_frame_goaway;
 
 typedef struct nghttp3_frame_priority_update {
-  nghttp3_frame_hd hd;
-  /* pri_elem_id is stream ID if hd.type ==
-     NGHTTP3_FRAME_PRIORITY_UPDATE.  It is push ID if hd.type ==
+  int64_t type;
+  /* pri_elem_id is stream ID if type ==
+     NGHTTP3_FRAME_PRIORITY_UPDATE.  It is push ID if type ==
      NGHTTP3_FRAME_PRIORITY_UPDATE_PUSH_ID.  It is undefined
      otherwise. */
   int64_t pri_elem_id;
@@ -117,14 +112,14 @@ typedef struct nghttp3_frame_priority_update {
 } nghttp3_frame_priority_update;
 
 typedef struct nghttp3_frame_origin {
-  nghttp3_frame_hd hd;
+  int64_t type;
   /* These fields are only used by server to send ORIGIN frame.
      Client never use them. */
   nghttp3_vec origin_list;
 } nghttp3_frame_origin;
 
 typedef union nghttp3_frame {
-  nghttp3_frame_hd hd;
+  int64_t type;
   nghttp3_frame_data data;
   nghttp3_frame_headers headers;
   nghttp3_frame_settings settings;
@@ -134,32 +129,36 @@ typedef union nghttp3_frame {
 } nghttp3_frame;
 
 /*
- * nghttp3_frame_write_hd writes frame header |hd| to |dest|.  This
- * function assumes that |dest| has enough space to write |hd|.
+ * nghttp3_frame_write_hd writes frame header consisting of |type| and
+ * |payloadlen| to |dest|.  This function assumes that |dest| has
+ * enough space to write the frame header.
  *
  * This function returns |dest| plus the number of bytes written.
  */
-uint8_t *nghttp3_frame_write_hd(uint8_t *dest, const nghttp3_frame_hd *hd);
+uint8_t *nghttp3_frame_write_hd(uint8_t *dest, int64_t type,
+                                int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_hd_len returns the number of bytes required to
- * write |hd|.  hd->length must be set.
+ * write a frame header consisting of |type| and |payloadlen|.
  */
-size_t nghttp3_frame_write_hd_len(const nghttp3_frame_hd *hd);
+size_t nghttp3_frame_write_hd_len(int64_t type, int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_settings writes SETTINGS frame |fr| to |dest|.
  * This function assumes that |dest| has enough space to write |fr|.
+ * |payloadlen| is the length of the frame payload.
  *
  * This function returns |dest| plus the number of bytes written.
  */
 uint8_t *nghttp3_frame_write_settings(uint8_t *dest,
-                                      const nghttp3_frame_settings *fr);
+                                      const nghttp3_frame_settings *fr,
+                                      int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_settings_len returns the number of bytes
- * required to write |fr|.  fr->hd.length is ignored.  This function
- * stores payload length in |*ppayloadlen|.
+ * required to write |fr|.  This function stores the frame payload
+ * length in |*ppayloadlen|.
  */
 size_t nghttp3_frame_write_settings_len(int64_t *pppayloadlen,
                                         const nghttp3_frame_settings *fr);
@@ -167,16 +166,18 @@ size_t nghttp3_frame_write_settings_len(int64_t *pppayloadlen,
 /*
  * nghttp3_frame_write_goaway writes GOAWAY frame |fr| to |dest|.
  * This function assumes that |dest| has enough space to write |fr|.
+ * |payloadlen| is the length of the frame payload.
  *
  * This function returns |dest| plus the number of bytes written.
  */
 uint8_t *nghttp3_frame_write_goaway(uint8_t *dest,
-                                    const nghttp3_frame_goaway *fr);
+                                    const nghttp3_frame_goaway *fr,
+                                    int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_goaway_len returns the number of bytes required
- * to write |fr|.  fr->hd.length is ignored.  This function stores
- * payload length in |*ppayloadlen|.
+ * to write |fr|.  This function stores the frame payload length in
+ * |*ppayloadlen|.
  */
 size_t nghttp3_frame_write_goaway_len(int64_t *ppayloadlen,
                                       const nghttp3_frame_goaway *fr);
@@ -184,18 +185,17 @@ size_t nghttp3_frame_write_goaway_len(int64_t *ppayloadlen,
 /*
  * nghttp3_frame_write_priority_update writes PRIORITY_UPDATE frame
  * |fr| to |dest|.  This function assumes that |dest| has enough space
- * to write |fr|.
+ * to write |fr|.  |payloadlen| is the length of the frame payload.
  *
  * This function returns |dest| plus the number of bytes written;
  */
-uint8_t *
-nghttp3_frame_write_priority_update(uint8_t *dest,
-                                    const nghttp3_frame_priority_update *fr);
+uint8_t *nghttp3_frame_write_priority_update(
+  uint8_t *dest, const nghttp3_frame_priority_update *fr, int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_priority_update_len returns the number of bytes
- * required to write |fr|.  fr->hd.length is ignored.  This function
- * stores payload length in |*ppayloadlen|.
+ * required to write |fr|.  This function stores the frame payload
+ * length in |*ppayloadlen|.
  */
 size_t nghttp3_frame_write_priority_update_len(
   int64_t *ppayloadlen, const nghttp3_frame_priority_update *fr);
@@ -203,16 +203,18 @@ size_t nghttp3_frame_write_priority_update_len(
 /*
  * nghttp3_frame_write_origin writes ORIGIN frame |fr| to |dest|.
  * This function assumes that |dest| has enough space to write |fr|.
+ * |payloadlen| is the length of the frame payload.
  *
  * This function returns |dest| plus the number of bytes written;
  */
 uint8_t *nghttp3_frame_write_origin(uint8_t *dest,
-                                    const nghttp3_frame_origin *fr);
+                                    const nghttp3_frame_origin *fr,
+                                    int64_t payloadlen);
 
 /*
  * nghttp3_frame_write_origin_len returns the number of bytes required
- * to write |fr|.  fr->hd.length is ignored.  This function stores
- * payload length in |*ppayloadlen|.
+ * to write |fr|.  This function stores the frame payload length in
+ * |*ppayloadlen|.
  */
 size_t nghttp3_frame_write_origin_len(int64_t *ppayloadlen,
                                       const nghttp3_frame_origin *fr);

--- a/tests/nghttp3_conn_test.c
+++ b/tests/nghttp3_conn_test.c
@@ -614,7 +614,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_MAX_FIELD_SECTION_SIZE;
   iv[0].value = 65536;
@@ -677,7 +677,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -706,7 +706,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_QPACK_MAX_TABLE_CAPACITY;
   iv[0].value = 4097;
@@ -740,7 +740,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_QPACK_MAX_TABLE_CAPACITY;
   iv[0].value = 4097;
@@ -769,7 +769,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_QPACK_BLOCKED_STREAMS;
   iv[0].value = 1;
@@ -797,7 +797,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_ENABLE_CONNECT_PROTOCOL;
   iv[0].value = 1;
@@ -825,7 +825,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_ENABLE_CONNECT_PROTOCOL;
   iv[0].value = 1;
@@ -853,7 +853,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_H3_DATAGRAM;
   iv[0].value = 1;
@@ -880,7 +880,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_H3_DATAGRAM;
   iv[0].value = 0;
@@ -907,7 +907,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_H3_DATAGRAM;
   iv[0].value = 2;
@@ -933,7 +933,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_ENABLE_CONNECT_PROTOCOL;
   iv[0].value = 1;
@@ -963,7 +963,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_ENABLE_CONNECT_PROTOCOL;
   iv[0].value = 1;
@@ -1065,7 +1065,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -1085,7 +1085,7 @@ void test_nghttp3_conn_read_control(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -1404,7 +1404,7 @@ void test_nghttp3_conn_submit_request(void) {
   setup_default_client(&conn);
   conn_write_initial_streams(conn);
 
-  fr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.settings.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 1;
   iv = fr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_QPACK_MAX_TABLE_CAPACITY;
@@ -1704,7 +1704,7 @@ static void check_http_header(const nghttp3_nv *nva, size_t nvlen, int request,
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)nva;
   fr.nvlen = nvlen;
 
@@ -2301,7 +2301,7 @@ void test_nghttp3_conn_http_content_length(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -2325,7 +2325,7 @@ void test_nghttp3_conn_http_content_length(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -2373,7 +2373,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -2395,7 +2395,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -2424,7 +2424,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -2448,7 +2448,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -2471,7 +2471,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -2501,7 +2501,7 @@ void test_nghttp3_conn_http_content_length_mismatch(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -2544,7 +2544,7 @@ void test_nghttp3_conn_http_non_final_response(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)infonv;
   fr.nvlen = nghttp3_arraylen(infonv);
 
@@ -2567,14 +2567,14 @@ void test_nghttp3_conn_http_non_final_response(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)infonv;
   fr.nvlen = nghttp3_arraylen(infonv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -2598,13 +2598,13 @@ void test_nghttp3_conn_http_non_final_response(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)infonv;
   fr.nvlen = nghttp3_arraylen(infonv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2656,13 +2656,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2684,13 +2684,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
@@ -2712,13 +2712,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2742,13 +2742,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2773,14 +2773,14 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
   nghttp3_write_frame_data(&buf, 99);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2804,13 +2804,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2831,7 +2831,7 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -2853,13 +2853,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2881,13 +2881,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)connect_reqnv;
   fr.nvlen = nghttp3_arraylen(connect_reqnv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2908,14 +2908,14 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)connect_reqnv;
   fr.nvlen = nghttp3_arraylen(connect_reqnv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
   nghttp3_write_frame_data(&buf, 11);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)trnv;
   fr.nvlen = nghttp3_arraylen(trnv);
 
@@ -2937,13 +2937,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)clnv;
   fr.nvlen = nghttp3_arraylen(clnv);
 
@@ -2975,13 +2975,13 @@ void test_nghttp3_conn_http_trailers(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resp_nva;
   fr.nvlen = nghttp3_arraylen(resp_nva);
 
   nghttp3_write_frame_qpack(&buf, &qenc, 0, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)clnv;
   fr.nvlen = nghttp3_arraylen(clnv);
 
@@ -3039,7 +3039,7 @@ void test_nghttp3_conn_http_ignore_content_length(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -3066,7 +3066,7 @@ void test_nghttp3_conn_http_ignore_content_length(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)reqnv;
   fr.nvlen = nghttp3_arraylen(reqnv);
 
@@ -3095,7 +3095,7 @@ void test_nghttp3_conn_http_ignore_content_length(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)cl_resnv;
   fr.nvlen = nghttp3_arraylen(cl_resnv);
 
@@ -3149,7 +3149,7 @@ void test_nghttp3_conn_http_record_request_method(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -3175,7 +3175,7 @@ void test_nghttp3_conn_http_record_request_method(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)resnv;
   fr.nvlen = nghttp3_arraylen(resnv);
 
@@ -3233,7 +3233,7 @@ void test_nghttp3_conn_http_error(void) {
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)dupschemenv;
   fr.nvlen = nghttp3_arraylen(dupschemenv);
 
@@ -3258,7 +3258,7 @@ void test_nghttp3_conn_http_error(void) {
   nghttp3_buf_reset(&buf);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)noschemenv;
   fr.nvlen = nghttp3_arraylen(noschemenv);
 
@@ -3290,7 +3290,7 @@ void test_nghttp3_conn_http_error(void) {
 
   nghttp3_buf_init(&ebuf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.nva = (nghttp3_nv *)noschemenv;
   fr.nvlen = nghttp3_arraylen(noschemenv);
 
@@ -3373,7 +3373,7 @@ void test_nghttp3_conn_qpack_blocked_stream(void) {
 
   assert_int(0, ==, rv);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_nva);
 
@@ -3449,7 +3449,7 @@ void test_nghttp3_conn_qpack_blocked_stream(void) {
 
   assert_int(0, ==, rv);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_nva);
 
@@ -3796,12 +3796,12 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, &fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 12;
 
   nghttp3_write_frame(&buf, &fr);
@@ -3835,17 +3835,17 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, &fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 12;
 
   nghttp3_write_frame(&buf, &fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 16;
 
   nghttp3_write_frame(&buf, &fr);
@@ -3873,12 +3873,12 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, &fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 101;
 
   nghttp3_write_frame(&buf, &fr);
@@ -3902,7 +3902,7 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -3923,12 +3923,12 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 1;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -3946,12 +3946,12 @@ void test_nghttp3_conn_recv_goaway(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_GOAWAY;
+  fr.type = NGHTTP3_FRAME_GOAWAY;
   fr.goaway.id = 0xff1;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -4003,7 +4003,7 @@ void test_nghttp3_conn_shutdown_server(void) {
   conn_write_initial_streams(conn);
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -4029,7 +4029,7 @@ void test_nghttp3_conn_shutdown_server(void) {
 
   nghttp3_buf_reset(&buf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -4120,6 +4120,7 @@ void test_nghttp3_conn_priority_update(void) {
     MAKE_NV("priority", "u=5, i"),
   };
   size_t i;
+  int64_t payloadlen;
 
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
 
@@ -4130,12 +4131,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=2,i";
   fr.priority_update.datalen = strlen("u=2,i");
@@ -4156,7 +4157,7 @@ void test_nghttp3_conn_priority_update(void) {
 
   nghttp3_buf_reset(&buf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)nva;
   fr.headers.nvlen = nghttp3_arraylen(nva);
 
@@ -4184,12 +4185,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.datalen = 0;
 
@@ -4209,7 +4210,7 @@ void test_nghttp3_conn_priority_update(void) {
 
   nghttp3_buf_reset(&buf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)nva;
   fr.headers.nvlen = nghttp3_arraylen(nva);
 
@@ -4239,12 +4240,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=6";
   fr.priority_update.datalen = strlen("u=6");
@@ -4268,12 +4269,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE_PUSH_ID;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE_PUSH_ID;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=6";
   fr.priority_update.datalen = strlen("u=6");
@@ -4295,19 +4296,19 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=2,i";
   fr.priority_update.datalen = strlen("u=2,i");
 
-  nghttp3_frame_write_priority_update_len(&fr.hd.length, &fr.priority_update);
-  fr.hd.length += 10;
-  buf.last = nghttp3_frame_write_priority_update(buf.last, &fr.priority_update);
+  nghttp3_frame_write_priority_update_len(&payloadlen, &fr.priority_update);
+  buf.last = nghttp3_frame_write_priority_update(buf.last, &fr.priority_update,
+                                                 payloadlen + 10);
   memset(buf.last, ' ', 10);
   buf.last += 10;
 
@@ -4338,12 +4339,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=1,aaaaa";
   fr.priority_update.datalen = strlen("u=1,aaaaa");
@@ -4371,12 +4372,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=1,aaaa";
   fr.priority_update.datalen = strlen("u=1,aaaa");
@@ -4406,12 +4407,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=1,aaaa";
   fr.priority_update.datalen = strlen("u=1,aaaa");
@@ -4445,12 +4446,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.data = (uint8_t *)"u=1,9x";
   fr.priority_update.datalen = strlen("u=1,9x");
@@ -4474,12 +4475,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 0;
   fr.priority_update.datalen = 0;
 
@@ -4498,7 +4499,7 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -4520,12 +4521,12 @@ void test_nghttp3_conn_priority_update(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
 
-  fr.hd.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
+  fr.type = NGHTTP3_FRAME_PRIORITY_UPDATE;
   fr.priority_update.pri_elem_id = 512;
   fr.priority_update.data = (uint8_t *)"u=1";
   fr.priority_update.datalen = strlen("u=1");
@@ -4580,7 +4581,7 @@ void test_nghttp3_conn_request_priority(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -4592,7 +4593,7 @@ void test_nghttp3_conn_request_priority(void) {
 
   nghttp3_buf_reset(&buf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)nva;
   fr.headers.nvlen = nghttp3_arraylen(nva);
 
@@ -4620,7 +4621,7 @@ void test_nghttp3_conn_request_priority(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  fr.hd.type = NGHTTP3_FRAME_SETTINGS;
+  fr.type = NGHTTP3_FRAME_SETTINGS;
   fr.settings.niv = 0;
 
   nghttp3_write_frame(&buf, (nghttp3_frame *)&fr);
@@ -4632,7 +4633,7 @@ void test_nghttp3_conn_request_priority(void) {
 
   nghttp3_buf_reset(&buf);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)badpri_nva;
   fr.headers.nvlen = nghttp3_arraylen(badpri_nva);
 
@@ -4682,7 +4683,7 @@ void test_nghttp3_conn_set_stream_priority(void) {
 
   for (i = 0; i < nghttp3_ringbuf_len(&stream->frq); ++i) {
     ent = nghttp3_ringbuf_get(&stream->frq, i);
-    if (ent->fr.hd.type != NGHTTP3_FRAME_PRIORITY_UPDATE) {
+    if (ent->fr.type != NGHTTP3_FRAME_PRIORITY_UPDATE) {
       continue;
     }
 
@@ -4782,7 +4783,7 @@ void test_nghttp3_conn_shutdown_stream_read(void) {
 
   assert_int(0, ==, rv);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_nva);
 
@@ -4915,7 +4916,7 @@ void test_nghttp3_conn_get_frame_payload_left(void) {
 
   buf.last = nghttp3_put_varint(buf.last, NGHTTP3_STREAM_TYPE_CONTROL);
 
-  settingsfr.settings.hd.type = NGHTTP3_FRAME_SETTINGS;
+  settingsfr.settings.type = NGHTTP3_FRAME_SETTINGS;
   iv = settingsfr.settings.iv;
   iv[0].id = NGHTTP3_SETTINGS_ID_MAX_FIELD_SECTION_SIZE;
   iv[0].value = 1000000009;
@@ -4956,7 +4957,7 @@ void test_nghttp3_conn_get_frame_payload_left(void) {
 
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -5114,7 +5115,7 @@ void test_nghttp3_conn_set_client_stream_priority(void) {
 
   assert_ptrdiff((nghttp3_ssize)nghttp3_vec_len(vec, (size_t)sveccnt), ==,
                  nread);
-  assert_int64(NGHTTP3_FRAME_PRIORITY_UPDATE, ==, fr.hd.type);
+  assert_int64(NGHTTP3_FRAME_PRIORITY_UPDATE, ==, fr.type);
   assert_memn_equal(prihd, strsize(prihd), fr.data, fr.datalen);
 
   rv = nghttp3_conn_add_write_offset(
@@ -5176,7 +5177,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   setup_default_server(&conn);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -5215,7 +5216,7 @@ void test_nghttp3_conn_rx_http_state(void) {
   assert_ptrdiff(1, ==, sveccnt);
   assert_int64(0, ==, stream_id);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_not_found_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_not_found_nva);
 
@@ -5226,7 +5227,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_ptrdiff((nghttp3_ssize)nghttp3_buf_len(&buf), ==, sconsumed);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)trailer_nva;
   fr.headers.nvlen = nghttp3_arraylen(trailer_nva);
 
@@ -5252,7 +5253,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   setup_default_server(&conn);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -5264,7 +5265,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_ptrdiff((nghttp3_ssize)nghttp3_buf_len(&buf) - 11, ==, sconsumed);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)trailer_nva;
   fr.headers.nvlen = nghttp3_arraylen(trailer_nva);
 
@@ -5307,7 +5308,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_int(0, ==, rv);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_not_found_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_not_found_nva);
 
@@ -5379,7 +5380,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_int(0, ==, rv);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)resp_not_found_nva;
   fr.headers.nvlen = nghttp3_arraylen(resp_not_found_nva);
 
@@ -5391,7 +5392,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_ptrdiff((nghttp3_ssize)nghttp3_buf_len(&buf) - 73, ==, sconsumed);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)trailer_nva;
   fr.headers.nvlen = nghttp3_arraylen(trailer_nva);
 
@@ -5415,10 +5416,9 @@ void test_nghttp3_conn_rx_http_state(void) {
   nghttp3_buf_reset(&buf);
   setup_default_server(&conn);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
-  fr.hd.length = 0;
+  fr.type = NGHTTP3_FRAME_HEADERS;
 
-  buf.last = nghttp3_frame_write_hd(buf.last, &fr.hd);
+  buf.last = nghttp3_frame_write_hd(buf.last, fr.type, 0);
 
   sconsumed = nghttp3_conn_read_stream(conn, 0, buf.pos, nghttp3_buf_len(&buf),
                                        /* fin = */ 0);
@@ -5433,7 +5433,7 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   setup_default_server(&conn);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
+  fr.type = NGHTTP3_FRAME_HEADERS;
   fr.headers.nva = (nghttp3_nv *)req_nva;
   fr.headers.nvlen = nghttp3_arraylen(req_nva);
 
@@ -5445,11 +5445,10 @@ void test_nghttp3_conn_rx_http_state(void) {
 
   assert_ptrdiff((nghttp3_ssize)nghttp3_buf_len(&buf) - 999, ==, sconsumed);
 
-  fr.hd.type = NGHTTP3_FRAME_HEADERS;
-  fr.hd.length = 0;
+  fr.type = NGHTTP3_FRAME_HEADERS;
 
   nghttp3_buf_reset(&buf);
-  buf.last = nghttp3_frame_write_hd(buf.last, &fr.hd);
+  buf.last = nghttp3_frame_write_hd(buf.last, fr.type, 0);
 
   sconsumed = nghttp3_conn_read_stream(conn, 0, buf.pos, nghttp3_buf_len(&buf),
                                        /* fin = */ 1);
@@ -5472,14 +5471,7 @@ void test_nghttp3_conn_push(void) {
   nghttp3_ssize nconsumed;
   nghttp3_stream *stream;
   nghttp3_frame fr = {
-    .settings =
-      {
-        .hd =
-          {
-            .type = NGHTTP3_FRAME_SETTINGS,
-          },
-        .niv = 0,
-      },
+    .settings.type = NGHTTP3_FRAME_SETTINGS,
   };
   int fin;
   nghttp3_vec vec[256];
@@ -5646,22 +5638,10 @@ void test_nghttp3_conn_push(void) {
 void test_nghttp3_conn_recv_origin(void) {
   nghttp3_conn *conn;
   nghttp3_frame settings = {
-    .settings =
-      {
-        .hd =
-          {
-            .type = NGHTTP3_FRAME_SETTINGS,
-          },
-      },
+    .settings.type = NGHTTP3_FRAME_SETTINGS,
   };
   nghttp3_frame fr = {
-    .origin =
-      {
-        .hd =
-          {
-            .type = NGHTTP3_FRAME_ORIGIN,
-          },
-      },
+    .origin.type = NGHTTP3_FRAME_ORIGIN,
   };
   uint8_t rawbuf[80 * 1024];
   nghttp3_buf buf;

--- a/tests/nghttp3_test_helper.h
+++ b/tests/nghttp3_test_helper.h
@@ -51,6 +51,11 @@
  */
 #define NGHTTP3_TEST_MAP_SEED 0
 
+typedef struct nghttp3_frame_hd {
+  int64_t type;
+  int64_t length;
+} nghttp3_frame_hd;
+
 /*
  * nghttp3_write_frame writes |fr| to |dest|.  This function
  * calculates the payload length and assigns it to fr->hd.length;


### PR DESCRIPTION
We only use length when writing a frame.  Directly pass the computed the length of the frame payload to the encoder function without setting it to nghttp3_frame_hd struct.  Now nghttp3_frame_hd is only used in tests.