### PR TITLE
Delete a stream that is blocked by QPACK on QUIC stream closure

### DIFF
--- a/lib/nghttp3_conn.h
+++ b/lib/nghttp3_conn.h
@@ -216,6 +216,9 @@ int nghttp3_conn_qpack_blocked_streams_push(nghttp3_conn *conn,
 
 void nghttp3_conn_qpack_blocked_streams_pop(nghttp3_conn *conn);
 
+void nghttp3_conn_qpack_blocked_streams_remove(nghttp3_conn *conn,
+                                               nghttp3_stream *stream);
+
 int nghttp3_conn_schedule_stream(nghttp3_conn *conn, nghttp3_stream *stream);
 
 int nghttp3_conn_ensure_stream_scheduled(nghttp3_conn *conn,

--- a/lib/nghttp3_stream.h
+++ b/lib/nghttp3_stream.h
@@ -114,10 +114,6 @@ typedef struct nghttp3_stream_read_state {
 /* NGHTTP3_STREAM_FLAG_READ_EOF indicates that remote endpoint sent
    fin. */
 #define NGHTTP3_STREAM_FLAG_READ_EOF 0x0020u
-/* NGHTTP3_STREAM_FLAG_CLOSED indicates that QUIC stream was closed.
-   nghttp3_stream object can still alive because it might be blocked
-   by QPACK decoder. */
-#define NGHTTP3_STREAM_FLAG_CLOSED 0x0040u
 /* NGHTTP3_STREAM_FLAG_SHUT_WR indicates that any further write
    operation to a stream is prohibited. */
 #define NGHTTP3_STREAM_FLAG_SHUT_WR 0x0100u


### PR DESCRIPTION
Previously, an nghttp3_stream that is blocked by QPACK is not deleted on QUIC stream closure, and it is deleted once it is unblocked.  But once QUIC stream is closed, we have nothing to do after receiving complete QPACK block.  This change just cancel QPACK, and deletes the nghttp3_stream once QUIC stream is closed even if it is blocked by QPACK.