### PR TITLE
cmake: do not require C++ for lib-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 # XXX using 0.1.90 instead of 0.2.0-DEV
-project(nghttp3 VERSION 1.11.90)
+project(nghttp3 VERSION 1.11.90 LANGUAGES C)
 
 # See versioning rule:
 #  https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
@@ -129,7 +129,11 @@ else()
     cmake_push_check_state()
     set(CMAKE_REQUIRED_LIBRARIES "-fsanitize=address")
     check_c_compiler_flag(-fsanitize=address C__fsanitize_address_VALID)
-    check_cxx_compiler_flag(-fsanitize=address CXX__fsanitize_address_VALID)
+    if(ENABLE_LIB_ONLY)
+      set(CXX__fsanitize_address_VALID TRUE)
+    else()
+      check_cxx_compiler_flag(-fsanitize=address CXX__fsanitize_address_VALID)
+    endif()
     cmake_pop_check_state()
     if(NOT C__fsanitize_address_VALID OR NOT CXX__fsanitize_address_VALID)
       message(WARNING "ENABLE_ASAN was requested, but not supported!")
@@ -151,6 +155,7 @@ endif()
 if(ENABLE_LIB_ONLY)
   set(ENABLE_EXAMPLES 0)
 else()
+  enable_language(CXX)
   set(ENABLE_EXAMPLES 1)
 endif()
 


### PR DESCRIPTION
C++ is only necessary to build examples.
