### PR TITLE
Remove nghttp3_settings.initial_ts

### DIFF
--- a/doc/source/programmers-guide.rst
+++ b/doc/source/programmers-guide.rst
@@ -69,7 +69,6 @@ effectively required to do HTTP/3 transaction below:
 The initialization functions also takes :type:`nghttp3_settings` which
 is a set of options to tweak HTTP3/ connection settings.
 `nghttp3_settings_default` fills the default values.
-`nghttp3_settings.initial_ts` should be set to the current timestamp.
 
 The *user_data* parameter to the initialization function is an opaque
 pointer and it is passed to callback functions.

--- a/fuzz/fuzz_http3serverreq.cc
+++ b/fuzz/fuzz_http3serverreq.cc
@@ -345,7 +345,6 @@ void run_fuzzer(const uint8_t *data, size_t size, size_t step) {
   settings.enable_connect_protocol =
     fuzzed_data_provider.ConsumeIntegral<uint8_t>();
   settings.h3_datagram = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
-  settings.initial_ts = 0;
 
   auto mem = *nghttp3_mem_default();
   mem.user_data = &fuzzed_data_provider;

--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -1764,19 +1764,14 @@ typedef struct nghttp3_settings {
   const nghttp3_vec *origin_list;
   /* The following fields have been added since NGHTTP3_SETTINGS_V3. */
   /**
-   * :member:`initial_ts` is an initial timestamp given to the
-   * library.  This field is available since v1.12.0.
-   */
-  nghttp3_tstamp initial_ts;
-  /**
    * :member:`glitch_ratelim_burst` is the maximum number of tokens
    * available to "glitch" rate limiter.  "glitch" is a suspicious
    * activity from a remote endpoint.  If detected, certain amount of
    * tokens are consumed.  If no tokens are available to consume, the
    * connection is closed.  The rate of token generation is specified
    * by :member:`glitch_ratelim_rate`.  This feature is enabled only
-   * when :member:`initial_ts` is set and `nghttp3_conn_read_stream2`
-   * is used.  This field has been available since v1.12.0.
+   * when `nghttp3_conn_read_stream2` is used.  This field has been
+   * available since v1.12.0.
    */
   uint64_t glitch_ratelim_burst;
   /**
@@ -2198,8 +2193,6 @@ typedef struct nghttp3_callbacks {
  *   <nghttp3_settings.qpack_blocked_streams>` = 0
  * - :member:`enable_connect_protocol
  *   <nghttp3_settings.enable_connect_protocol>` = 0
- * - :member:`initial_ts <nghttp3_settings.initial_ts>` =
- *   ``UINT64_MAX``
  * - :member:`glitch_ratelim_burst
  *   <nghttp3_settings.glitch_ratelim_burst>` = 1000
  * - :member:`glitch_ratelim_rate

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -233,7 +233,7 @@ static int conn_call_end_origin(nghttp3_conn *conn) {
 
 static int conn_glitch_ratelim_drain(nghttp3_conn *conn, uint64_t n,
                                      nghttp3_tstamp ts) {
-  if (ts == UINT64_MAX || conn->glitch_rlim.ts == UINT64_MAX) {
+  if (ts == UINT64_MAX) {
     return 0;
   }
 
@@ -319,7 +319,7 @@ static int conn_new(nghttp3_conn **pconn, int server, int callbacks_version,
   nghttp3_idtr_init(&conn->remote.bidi.idtr, mem);
 
   nghttp3_ratelim_init(&conn->glitch_rlim, settings->glitch_ratelim_burst,
-                       settings->glitch_ratelim_rate, settings->initial_ts);
+                       settings->glitch_ratelim_rate, 0);
 
   conn->callbacks = *callbacks;
   conn->local.settings = *settings;

--- a/lib/nghttp3_settings.c
+++ b/lib/nghttp3_settings.c
@@ -42,7 +42,6 @@ void nghttp3_settings_default_versioned(int settings_version,
 
   switch (settings_version) {
   case NGHTTP3_SETTINGS_VERSION:
-    settings->initial_ts = UINT64_MAX;
     settings->glitch_ratelim_burst = NGHTTP3_DEFAULT_GLITCH_RATELIM_BURST;
     settings->glitch_ratelim_rate = NGHTTP3_DEFAULT_GLITCH_RATELIM_RATE;
     /* fall through */

--- a/tests/nghttp3_conn_test.c
+++ b/tests/nghttp3_conn_test.c
@@ -431,7 +431,6 @@ static void setup_conn_with_options(nghttp3_conn **pconn, int server,
 
   if (opts.settings == NULL) {
     nghttp3_settings_default(&settings);
-    settings.initial_ts = 0;
     opts.settings = &settings;
   }
 
@@ -1176,7 +1175,6 @@ void test_nghttp3_conn_write_control(void) {
   nghttp3_settings_default(&settings);
   settings.h3_datagram = 1;
   settings.enable_connect_protocol = 1;
-  settings.initial_ts = 0;
 
   conn_options_clear(&opts);
   opts.settings = &settings;
@@ -1611,7 +1609,6 @@ void test_nghttp3_conn_http_request(void) {
 
   settings.qpack_max_dtable_capacity = 4096;
   settings.qpack_blocked_streams = 100;
-  settings.initial_ts = 0;
 
   clud.data.left = 2000;
   clud.data.step = 1200;
@@ -1733,7 +1730,6 @@ static void check_http_header(const nghttp3_nv *nva, size_t nvlen, int request,
 
   nghttp3_settings_default(&settings);
   settings.enable_connect_protocol = 1;
-  settings.initial_ts = 0;
 
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
   nghttp3_qpack_encoder_init(&qenc, 0, NGHTTP3_TEST_MAP_SEED, mem);
@@ -3262,7 +3258,6 @@ void test_nghttp3_conn_http_error(void) {
   nghttp3_settings_default(&settings);
   settings.qpack_max_dtable_capacity = 4096;
   settings.qpack_blocked_streams = 100;
-  settings.initial_ts = 0;
 
   /* duplicated :scheme */
   nghttp3_buf_wrap_init(&buf, rawbuf, sizeof(rawbuf));
@@ -3384,7 +3379,6 @@ void test_nghttp3_conn_qpack_blocked_stream(void) {
   nghttp3_settings_default(&settings);
   settings.qpack_max_dtable_capacity = 4096;
   settings.qpack_blocked_streams = 100;
-  settings.initial_ts = 0;
 
   /* Closing QUIC stream deletes a stream that is blocked by QPACK */
   nghttp3_buf_init(&ebuf);
@@ -4888,7 +4882,6 @@ void test_nghttp3_conn_shutdown_stream_read(void) {
   nghttp3_settings_default(&settings);
   settings.qpack_max_dtable_capacity = 4096;
   settings.qpack_blocked_streams = 100;
-  settings.initial_ts = 0;
 
   /* Shutting down read-side stream when a stream is blocked by QPACK
      dependency. */
@@ -6161,7 +6154,6 @@ void test_nghttp3_conn_write_origin(void) {
   origin_list.base = (uint8_t *)origins;
   origin_list.len = strsize(origins);
   settings.origin_list = &origin_list;
-  settings.initial_ts = 0;
 
   conn_options_clear(&opts);
   opts.settings = &settings;
@@ -6196,7 +6188,6 @@ void test_nghttp3_conn_write_origin(void) {
   origin_list.base = NULL;
   origin_list.len = 0;
   settings.origin_list = &origin_list;
-  settings.initial_ts = 0;
 
   conn_options_clear(&opts);
   opts.settings = &settings;
@@ -6232,7 +6223,6 @@ void test_nghttp3_conn_write_origin(void) {
   origin_list.base = long_origin;
   origin_list.len = sizeof(long_origin);
   settings.origin_list = &origin_list;
-  settings.initial_ts = 0;
 
   conn_options_clear(&opts);
   opts.settings = &settings;

--- a/tests/nghttp3_settings_test.c
+++ b/tests/nghttp3_settings_test.c
@@ -83,7 +83,6 @@ void test_nghttp3_settings_convert_to_latest(void) {
                dest->enable_connect_protocol);
   assert_uint8(srcbuf.h3_datagram, ==, dest->h3_datagram);
   assert_ptr_equal(srcbuf.origin_list, dest->origin_list);
-  assert_uint64(UINT64_MAX, ==, dest->initial_ts);
   assert_uint64(NGHTTP3_DEFAULT_GLITCH_RATELIM_BURST, ==,
                 dest->glitch_ratelim_burst);
   assert_uint64(NGHTTP3_DEFAULT_GLITCH_RATELIM_RATE, ==,
@@ -111,7 +110,6 @@ void test_nghttp3_settings_convert_to_old(void) {
   src.enable_connect_protocol = 1;
   src.h3_datagram = 1;
   src.origin_list = &origin_list;
-  src.initial_ts = 6398888;
   src.glitch_ratelim_burst = 74111;
   src.glitch_ratelim_rate = 6831;
 
@@ -132,7 +130,6 @@ void test_nghttp3_settings_convert_to_old(void) {
                destbuf.enable_connect_protocol);
   assert_uint8(src.h3_datagram, ==, destbuf.h3_datagram);
   assert_ptr_equal(src.origin_list, destbuf.origin_list);
-  assert_uint64(0, ==, destbuf.initial_ts);
   assert_uint64(0, ==, destbuf.glitch_ratelim_burst);
   assert_uint64(0, ==, destbuf.glitch_ratelim_rate);
 }


### PR DESCRIPTION
Because the token is still full until the first anomaly is detected, the initial value of timestamp can be 0, that eliminates the need for initial_ts.