### PR TITLE
L5: Fix int16_t intermediate cast on HTTP status code

### DIFF
--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -462,7 +462,8 @@ static int http_response_on_header(nghttp3_http_state *http,
     }
     val = parse_uint(nv->value->base, nv->value->len);
     http->status_code = (int32_t)val;
-    if (http->status_code < 100 || http->status_code == 101) {
+    if (http->status_code < 100 || http->status_code == 101 ||
+        http->status_code > 599) {
       return NGHTTP3_ERR_MALFORMED_HTTP_HEADER;
     }
     break;

--- a/lib/nghttp3_http.c
+++ b/lib/nghttp3_http.c
@@ -455,11 +455,13 @@ static int http_response_on_header(nghttp3_http_state *http,
                                    const nghttp3_qpack_nv *nv, int trailers) {
   switch (nv->token) {
   case NGHTTP3_QPACK_TOKEN__STATUS: {
+    int64_t val;
     if (!check_pseudo_header(http, nv, NGHTTP3_HTTP_FLAG__STATUS) ||
         nv->value->len != 3) {
       return NGHTTP3_ERR_MALFORMED_HTTP_HEADER;
     }
-    http->status_code = (int16_t)parse_uint(nv->value->base, nv->value->len);
+    val = parse_uint(nv->value->base, nv->value->len);
+    http->status_code = (int32_t)val;
     if (http->status_code < 100 || http->status_code == 101) {
       return NGHTTP3_ERR_MALFORMED_HTTP_HEADER;
     }


### PR DESCRIPTION
Fixes #474

See the issue for detailed problem analysis and solution explanation.