### PR TITLE
conv: Remove nghttp3_put_varint variants

### DIFF
--- a/lib/nghttp3_conv.h
+++ b/lib/nghttp3_conv.h
@@ -154,22 +154,6 @@ uint8_t *nghttp3_put_uvarint(uint8_t *p, uint64_t n);
 size_t nghttp3_put_uvarintlen(uint64_t n);
 
 /*
- * nghttp3_put_varint writes |n| in |p| using variable-length integer
- * encoding.  It returns the one beyond of the last written position.
- */
-static inline uint8_t *nghttp3_put_varint(uint8_t *p, int64_t n) {
-  return nghttp3_put_uvarint(p, (uint64_t)n);
-}
-
-/*
- * nghttp3_put_varintlen returns the required number of bytes to
- * encode |n|.
- */
-static inline size_t nghttp3_put_varintlen(int64_t n) {
-  return nghttp3_put_uvarintlen((uint64_t)n);
-}
-
-/*
  * nghttp3_ord_stream_id returns the ordinal number of |stream_id|.
  */
 uint64_t nghttp3_ord_stream_id(int64_t stream_id);

--- a/lib/nghttp3_frame.c
+++ b/lib/nghttp3_frame.c
@@ -76,14 +76,14 @@ size_t nghttp3_frame_write_settings_len(uint64_t *ppayloadlen,
 uint8_t *nghttp3_frame_write_goaway(uint8_t *p, const nghttp3_frame_goaway *fr,
                                     uint64_t payloadlen) {
   p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
-  p = nghttp3_put_varint(p, fr->id);
+  p = nghttp3_put_uvarint(p, (uint64_t)fr->id);
 
   return p;
 }
 
 size_t nghttp3_frame_write_goaway_len(uint64_t *ppayloadlen,
                                       const nghttp3_frame_goaway *fr) {
-  size_t payloadlen = nghttp3_put_varintlen(fr->id);
+  size_t payloadlen = nghttp3_put_uvarintlen((uint64_t)fr->id);
 
   *ppayloadlen = payloadlen;
 
@@ -94,7 +94,7 @@ size_t nghttp3_frame_write_goaway_len(uint64_t *ppayloadlen,
 uint8_t *nghttp3_frame_write_priority_update(
   uint8_t *p, const nghttp3_frame_priority_update *fr, uint64_t payloadlen) {
   p = nghttp3_frame_write_hd(p, fr->type, payloadlen);
-  p = nghttp3_put_varint(p, fr->pri_elem_id);
+  p = nghttp3_put_uvarint(p, (uint64_t)fr->pri_elem_id);
   if (fr->datalen) {
     p = nghttp3_cpymem(p, fr->data, fr->datalen);
   }
@@ -104,7 +104,8 @@ uint8_t *nghttp3_frame_write_priority_update(
 
 size_t nghttp3_frame_write_priority_update_len(
   uint64_t *ppayloadlen, const nghttp3_frame_priority_update *fr) {
-  size_t payloadlen = nghttp3_put_varintlen(fr->pri_elem_id) + fr->datalen;
+  size_t payloadlen =
+    nghttp3_put_uvarintlen((uint64_t)fr->pri_elem_id) + fr->datalen;
 
   *ppayloadlen = payloadlen;
 


### PR DESCRIPTION
Remove nghttp3_put_varint variants and just use nghttp3_put_uvarint instead.