### PR TITLE
Add nghttp3_conn_stream_flushed

### DIFF
--- a/lib/includes/nghttp3/nghttp3.h
+++ b/lib/includes/nghttp3/nghttp3.h
@@ -2628,6 +2628,23 @@ NGHTTP3_EXTERN int nghttp3_conn_add_write_offset(nghttp3_conn *conn,
 /**
  * @function
  *
+ * `nghttp3_conn_is_stream_flushed` returns nonzero if all stream data
+ * for a stream identified by |stream_id| so far have been accepted by
+ * QUIC stack.  This means that the cumulative number of bytes that
+ * `nghttp3_conn_add_write_offset` notified covers all stream data
+ * currently held.  This does not mean more stream data cannot be
+ * submitted to this stream via :type:`nghttp3_read_data_callback` and
+ * all stream data have been acknowledged.
+ *
+ * If there is no stream identified by |stream_id|, this function
+ * returns 0.
+ */
+NGHTTP3_EXTERN int nghttp3_conn_is_stream_flushed(const nghttp3_conn *conn,
+                                                  int64_t stream_id);
+
+/**
+ * @function
+ *
  * `nghttp3_conn_add_ack_offset` tells |conn| the number of bytes |n|
  * for stream denoted by |stream_id| QUIC stack has acknowledged.
  *

--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2979,3 +2979,14 @@ int nghttp3_conn_is_drained2(const nghttp3_conn *conn) {
          nghttp3_stream_outq_write_done(conn->tx.ctrl) &&
          nghttp3_ringbuf_len(&conn->tx.ctrl->frq) == 0;
 }
+
+int nghttp3_conn_is_stream_flushed(const nghttp3_conn *conn,
+                                   int64_t stream_id) {
+  const nghttp3_stream *stream = nghttp3_conn_find_stream(conn, stream_id);
+
+  if (stream == NULL) {
+    return 0;
+  }
+
+  return nghttp3_stream_outq_write_done(stream);
+}

--- a/tests/nghttp3_conn_test.c
+++ b/tests/nghttp3_conn_test.c
@@ -1543,12 +1543,19 @@ void test_nghttp3_conn_submit_request(void) {
 
   assert_int64(0, ==, stream_id);
   assert_ptrdiff(2, ==, sveccnt);
+  assert_false(nghttp3_conn_is_stream_flushed(conn, stream_id));
 
   len = nghttp3_vec_len(vec, (size_t)sveccnt);
   for (i = 0; i < len; ++i) {
     rv = nghttp3_conn_add_write_offset(conn, 0, 1);
 
     assert_int(0, ==, rv);
+
+    if (i == len - 1) {
+      assert_true(nghttp3_conn_is_stream_flushed(conn, stream_id));
+    } else {
+      assert_false(nghttp3_conn_is_stream_flushed(conn, stream_id));
+    }
 
     rv = nghttp3_conn_add_ack_offset(conn, 0, 1);
 
@@ -1567,6 +1574,12 @@ void test_nghttp3_conn_submit_request(void) {
     rv = nghttp3_conn_add_write_offset(conn, 0, 1);
 
     assert_int(0, ==, rv);
+
+    if (i == len - 1) {
+      assert_true(nghttp3_conn_is_stream_flushed(conn, stream_id));
+    } else {
+      assert_false(nghttp3_conn_is_stream_flushed(conn, stream_id));
+    }
 
     rv = nghttp3_conn_add_ack_offset(conn, 0, 1);
 


### PR DESCRIPTION
nghttp3_conn_stream_flushed tells that all stream data held so far have been accepted by QUIC stack.