### PR TITLE
Avoid duplicate signed char generic association with MSVC

### DIFF
--- a/lib/nghttp3_macro.h
+++ b/lib/nghttp3_macro.h
@@ -68,12 +68,12 @@ nghttp3_max_def(unsigned_int, unsigned int)
 nghttp3_max_def(unsigned_short_int, unsigned short int)
 nghttp3_max_def(unsigned_char, unsigned char)
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944
 #  define nghttp3_max_signed_char_assoc
-#else /* !defined(_MSC_VER) */
+#else /* !(defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944) */
 #  define nghttp3_max_signed_char_assoc                                    \
     signed char: nghttp3_max_signed_char,
-#endif /* !defined(_MSC_VER) */
+#endif /* !(defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944) */
 
 #define nghttp3_max(A, B)                                                      \
   _Generic((A),                                                                \
@@ -115,12 +115,12 @@ nghttp3_min_def(unsigned_int, unsigned int)
 nghttp3_min_def(unsigned_short_int, unsigned short int)
 nghttp3_min_def(unsigned_char, unsigned char)
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944
 #  define nghttp3_min_signed_char_assoc
-#else /* !defined(_MSC_VER) */
+#else /* !(defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944) */
 #  define nghttp3_min_signed_char_assoc                                    \
     signed char: nghttp3_min_signed_char,
-#endif /* !defined(_MSC_VER) */
+#endif /* !(defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1944) */
 
 #define nghttp3_min(A, B)                                                      \
   _Generic((A),                                                                \

--- a/lib/nghttp3_macro.h
+++ b/lib/nghttp3_macro.h
@@ -68,6 +68,13 @@ nghttp3_max_def(unsigned_int, unsigned int)
 nghttp3_max_def(unsigned_short_int, unsigned short int)
 nghttp3_max_def(unsigned_char, unsigned char)
 
+#ifdef _MSC_VER
+#  define nghttp3_max_signed_char_assoc
+#else /* !defined(_MSC_VER) */
+#  define nghttp3_max_signed_char_assoc                                    \
+    signed char: nghttp3_max_signed_char,
+#endif /* !defined(_MSC_VER) */
+
 #define nghttp3_max(A, B)                                                      \
   _Generic((A),                                                                \
     long long int: nghttp3_max_long_long_int,                                  \
@@ -77,7 +84,7 @@ nghttp3_max_def(unsigned_char, unsigned char)
       long int: nghttp3_max_long_int,                                          \
       int: nghttp3_max_int,                                                    \
       short int: nghttp3_max_short_int,                                        \
-      signed char: nghttp3_max_signed_char,                                    \
+      nghttp3_max_signed_char_assoc                                           \
       char: nghttp3_max_char,                                                  \
       unsigned long long int: nghttp3_max_unsigned_long_long_int,              \
       unsigned long int: nghttp3_max_unsigned_long_int,                        \
@@ -85,7 +92,7 @@ nghttp3_max_def(unsigned_char, unsigned char)
       unsigned short int: nghttp3_max_unsigned_short_int,                      \
       unsigned char: nghttp3_max_unsigned_char),                               \
     short int: nghttp3_max_short_int,                                          \
-    signed char: nghttp3_max_signed_char,                                      \
+    nghttp3_max_signed_char_assoc                                             \
     char: nghttp3_max_char,                                                    \
     unsigned long long int: nghttp3_max_unsigned_long_long_int,                \
     unsigned long int: nghttp3_max_unsigned_long_int,                          \
@@ -108,6 +115,13 @@ nghttp3_min_def(unsigned_int, unsigned int)
 nghttp3_min_def(unsigned_short_int, unsigned short int)
 nghttp3_min_def(unsigned_char, unsigned char)
 
+#ifdef _MSC_VER
+#  define nghttp3_min_signed_char_assoc
+#else /* !defined(_MSC_VER) */
+#  define nghttp3_min_signed_char_assoc                                    \
+    signed char: nghttp3_min_signed_char,
+#endif /* !defined(_MSC_VER) */
+
 #define nghttp3_min(A, B)                                                      \
   _Generic((A),                                                                \
     long long int: nghttp3_min_long_long_int,                                  \
@@ -117,7 +131,7 @@ nghttp3_min_def(unsigned_char, unsigned char)
       long int: nghttp3_min_long_int,                                          \
       int: nghttp3_min_int,                                                    \
       short int: nghttp3_min_short_int,                                        \
-      signed char: nghttp3_min_signed_char,                                    \
+      nghttp3_min_signed_char_assoc                                           \
       char: nghttp3_min_char,                                                  \
       unsigned long long int: nghttp3_min_unsigned_long_long_int,              \
       unsigned long int: nghttp3_min_unsigned_long_int,                        \
@@ -125,7 +139,7 @@ nghttp3_min_def(unsigned_char, unsigned char)
       unsigned short int: nghttp3_min_unsigned_short_int,                      \
       unsigned char: nghttp3_min_unsigned_char),                               \
     short int: nghttp3_min_short_int,                                          \
-    signed char: nghttp3_min_signed_char,                                      \
+    nghttp3_min_signed_char_assoc                                             \
     char: nghttp3_min_char,                                                    \
     unsigned long long int: nghttp3_min_unsigned_long_long_int,                \
     unsigned long int: nghttp3_min_unsigned_long_int,                          \


### PR DESCRIPTION
## What does this PR do?

MSVC rejects the `nghttp3_max` and `nghttp3_min` _Generic association lists because both signed char and char are present and are treated as compatible types, which causes C7700 errors when building nghttp3 with Visual Studio 2022. 

This change omits the signed char generic association only for MSVC, while preserving the existing behavior for other compilers. The actual nghttp3 call sites use integer, size_t, and uint64_t values, so this avoids the MSVC compile failure without changing the non-MSVC path.