### PR TITLE
lib/CMakeLists.txt: Include GNUInstallDirs to use CMAKE_INSTALL_LIBDIR

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,15 +66,17 @@ set(nghttp3_SOURCES
   sfparse/sfparse.c
 )
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 set(NGHTTP3_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(NGHTTP3_VERSION_CONFIG "${NGHTTP3_GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 set(NGHTTP3_PROJECT_CONFIG "${NGHTTP3_GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
 set(NGHTTP3_TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(NGHTTP3_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(NGHTTP3_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(NGHTTP3_NAMESPACE "${PROJECT_NAME}::")
 set(NGHTTP3_VERSION ${PROJECT_VERSION})
 
-include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   "${NGHTTP3_VERSION_CONFIG}" VERSION ${NGHTTP3_VERSION} COMPATIBILITY SameMajorVersion
 )


### PR DESCRIPTION
This ensures the path for .cmake follows the common pattern to include the arch, e.g. `usr/lib/x86_64-linux-gnu/cmake/nghttp3`

Tested at: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/33609

Reported at: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/work_items/2036

Same patch sent to ngtcp2: https://github.com/ngtcp2/ngtcp2/pull/2274