### PR TITLE
Prevent division by zero in QPACK Required Insert Count reconstruction

### DIFF
--- a/lib/nghttp3_qpack.c
+++ b/lib/nghttp3_qpack.c
@@ -3919,6 +3919,10 @@ int nghttp3_qpack_decoder_reconstruct_ricnt(
     decoder->ctx.hard_max_dtable_capacity / NGHTTP3_QPACK_ENTRY_OVERHEAD;
   full = 2 * max_ents;
 
+  if (full == 0) {
+    return NGHTTP3_ERR_QPACK_DECOMPRESSION_FAILED;
+  }
+
   if (encricnt > full) {
     return NGHTTP3_ERR_QPACK_DECOMPRESSION_FAILED;
   }

--- a/tests/nghttp3_qpack_test.c
+++ b/tests/nghttp3_qpack_test.c
@@ -914,6 +914,16 @@ void test_nghttp3_qpack_decoder_reconstruct_ricnt(void) {
   assert_uint64(8, ==, ricnt);
 
   nghttp3_qpack_decoder_free(&dec);
+
+  /* A nonzero Required Insert Count is invalid when the dynamic table
+     cannot hold even one entry. */
+  nghttp3_qpack_decoder_init(&dec, 0, 1, mem);
+
+  rv = nghttp3_qpack_decoder_reconstruct_ricnt(&dec, &ricnt, 1);
+
+  assert_int(NGHTTP3_ERR_QPACK_DECOMPRESSION_FAILED, ==, rv);
+
+  nghttp3_qpack_decoder_free(&dec);
 }
 
 void test_nghttp3_qpack_decoder_read_encoder(void) {


### PR DESCRIPTION
## Summary

Handle QPACK Required Insert Count reconstruction when the decoder dynamic table cannot hold a single entry.

## Details

When `hard_max_dtable_capacity` is smaller than `NGHTTP3_QPACK_ENTRY_OVERHEAD`, the calculated number of entries is zero. For a nonzero encoded Required Insert Count, the reconstruction logic previously computed `full == 0` and then divided by `full`, causing a division-by-zero crash.

This patch:

- Detects a zero reconstruction range before division.
- Returns `NGHTTP3_ERR_QPACK_DECOMPRESSION_FAILED`.
- Adds a regression test using a decoder with zero dynamic-table capacity.

## Security Impact

A malformed peer-controlled QPACK header block could crash the decoder process. The invalid input is now rejected safely.
