### PR TITLE
Assert the control stream

### DIFF
--- a/lib/nghttp3_conn.c
+++ b/lib/nghttp3_conn.c
@@ -2970,6 +2970,8 @@ int nghttp3_conn_set_client_stream_priority(nghttp3_conn *conn,
     memcpy(buf, data, datalen);
   }
 
+  assert(conn->tx.ctrl);
+
   rv = nghttp3_stream_frq_emplace(conn->tx.ctrl, &fr);
   if (rv != 0) {
     nghttp3_mem_free(conn->mem, buf);


### PR DESCRIPTION
Without the control stream, HTTP/3 does not work.  Assert that conn->tx.ctrl is not NULL as we do in the other places.